### PR TITLE
Preliminary Models and Bifrost RPC Spec

### DIFF
--- a/protobuf/bifrost/bifrost_rpc.proto
+++ b/protobuf/bifrost/bifrost_rpc.proto
@@ -6,58 +6,88 @@ import 'models/common.proto';
 import 'models/block.proto';
 import 'models/transaction.proto';
 
-service ToplGrpc {
+service NodeRpc {
+  // Submit a proven Transaction to the node
   rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
+  // Read the contents of the node's mempool
   rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
 
+  // retrieve a Block Header by its ID
   rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
+
+  // retrieve a Block Body by its ID
   rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
+
+  // retrieve a Transaction by its ID
   rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
 
+
+  // retrieve the Block ID associated with a height, according to the node's canonical chain
   rpc FetchBlockIdAtHeight (FetchBlockIdAtHeightReq) returns (FetchBlockIdAtHeightRes);
 
 }
 
+// Request type for BroadcastTransaction
 message BroadcastTransactionReq {
+  // A "proven" Transaction that is meant to be included in the blockchain
   co.topl.proto.models.Transaction transaction = 1;
 }
 
+// Response type for BroadcastTransaction
 message BroadcastTransactionRes {}
 
+// Request type for CurrentMempool
 message CurrentMempoolReq {}
 
+// Response type for CurrentMempool
 message CurrentMempoolRes {
+  // A list of Transaction IDs that are currently in the node's mempool
   repeated co.topl.proto.models.TransactionId transactionIds = 1;
 }
 
+// Request type for FetchBlockHeader
 message FetchBlockHeaderReq {
+  // The ID of the block to retrieve
   co.topl.proto.models.BlockId blockId = 1;
 }
 
+// Response type for FetchBlockHeader
 message FetchBlockHeaderRes {
-  co.topl.proto.models.BlockHeader header = 1;
+  // The Block Header associated with the requested ID.  None/null if not found.
+  optional co.topl.proto.models.BlockHeader header = 1;
 }
 
+// Request type for FetchBlockBody
 message FetchBlockBodyReq {
+  // The ID of the block to retrieve
   co.topl.proto.models.BlockId blockId = 1;
 }
 
+// Response type for FetchBlockBody
 message FetchBlockBodyRes {
-  co.topl.proto.models.BlockBody body = 1;
+  // The Block Body associated with the requested ID.  None/null if not found.
+  optional co.topl.proto.models.BlockBody body = 1;
 }
 
+// Request type for FetchTransaction
 message FetchTransactionReq {
   co.topl.proto.models.TransactionId transactionId = 1;
 }
 
+// Response type for FetchTransaction
 message FetchTransactionRes {
-  co.topl.proto.models.Transaction transaction = 1;
+  // The Transaction associated with the requested ID.  None/null if not found.
+  optional co.topl.proto.models.Transaction transaction = 1;
 }
 
+// Request type for FetchBlockIdAtHeight
 message FetchBlockIdAtHeightReq {
+  // The height of interest
   uint64 height = 1;
 }
 
+// Response type for FetchBlockIdAtHeight
 message FetchBlockIdAtHeightRes {
-  co.topl.proto.models.BlockId blockId = 1;
+  // The Block ID associated with the requested height.  None/null if not found.
+  optional co.topl.proto.models.BlockId blockId = 1;
 }

--- a/protobuf/bifrost/bifrost_rpc.proto
+++ b/protobuf/bifrost/bifrost_rpc.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package co.topl.proto.services;
+
+import 'models/common.proto';
+import 'models/block.proto';
+import 'models/transaction.proto';
+
+service ToplGrpc {
+  rpc BroadcastTransaction (BroadcastTransactionReq) returns (BroadcastTransactionRes);
+  rpc CurrentMempool (CurrentMempoolReq) returns (CurrentMempoolRes);
+
+  rpc FetchBlockHeader (FetchBlockHeaderReq) returns (FetchBlockHeaderRes);
+  rpc FetchBlockBody (FetchBlockBodyReq) returns (FetchBlockBodyRes);
+  rpc FetchTransaction (FetchTransactionReq) returns (FetchTransactionRes);
+
+  rpc FetchBlockIdAtHeight (FetchBlockIdAtHeightReq) returns (FetchBlockIdAtHeightRes);
+
+}
+
+message BroadcastTransactionReq {
+  co.topl.proto.models.Transaction transaction = 1;
+}
+
+message BroadcastTransactionRes {}
+
+message CurrentMempoolReq {}
+
+message CurrentMempoolRes {
+  repeated co.topl.proto.models.TransactionId transactionIds = 1;
+}
+
+message FetchBlockHeaderReq {
+  co.topl.proto.models.BlockId blockId = 1;
+}
+
+message FetchBlockHeaderRes {
+  co.topl.proto.models.BlockHeader header = 1;
+}
+
+message FetchBlockBodyReq {
+  co.topl.proto.models.BlockId blockId = 1;
+}
+
+message FetchBlockBodyRes {
+  co.topl.proto.models.BlockBody body = 1;
+}
+
+message FetchTransactionReq {
+  co.topl.proto.models.TransactionId transactionId = 1;
+}
+
+message FetchTransactionRes {
+  co.topl.proto.models.Transaction transaction = 1;
+}
+
+message FetchBlockIdAtHeightReq {
+  uint64 height = 1;
+}
+
+message FetchBlockIdAtHeightRes {
+  co.topl.proto.models.BlockId blockId = 1;
+}

--- a/protobuf/models/address.proto
+++ b/protobuf/models/address.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/common.proto';
+import 'models/verification_key.proto';
+import 'models/proof.proto';
+
+// Captures the "ownership" of a UTxO
+message FullAddress {
+  // A byte prefix indicating the network instance to which this address belongs
+  NetworkPrefix networkPrefix = 1;
+  // Commitment to the logic for who may spend a UTxO
+  SpendingAddress spendingAddress = 2;
+  // Encodes which staking account which owns the funds of the UTxO
+  StakingAddress stakingAddress = 3;
+  // TODO: What do we name this?
+  ProofKnowledgeEd25519 commitment = 4;
+}
+
+// Commits to a lock/proposition
+message SpendingAddress {
+  // The evidence of the proposition
+  TypedEvidence typedEvidence = 1;
+}
+
+// Encodes the staking account which owns the funds of the UTxO
+message StakingAddress {
+  oneof sealed_value {
+    StakingAddressOperator operator = 1;
+    StakingAddressNonStaking nonStaking = 2;
+  }
+}
+
+// A type of StakingAddress in which Arbits (the staking token) are owned by a block producer
+message StakingAddressOperator {
+  // The operator's verification key
+  VerificationKeyEd25519 vk = 1;
+}
+
+// A type of StakingAddress in which Arbits are not used for staking at all.  These arbits are excluded
+// from the total active stake pool when considering relative stake calculations
+message StakingAddressNonStaking {}

--- a/protobuf/models/block.proto
+++ b/protobuf/models/block.proto
@@ -17,11 +17,11 @@ message BlockHeader {
   bytes txRoot = 3;
   // A fuzzy search for addresses associated with this block
   bytes bloomFilter = 4;
-  // The UNIX timestamp (ms) when the block was created
+  // The UTC UNIX timestamp (ms) when the block was created
   uint64 timestamp = 5;
   // The 1-based index of this block in the blockchain
   uint64 height = 6;
-  // The time-slot in which the block producer is eligible to produce this block
+  // The time-slot in which the block producer created the block
   uint64 slot = 7;
   // A certificate indicating that the block producer was eligible to make this block
   EligibilityCertificate eligibilityCertificate = 8;

--- a/protobuf/models/block.proto
+++ b/protobuf/models/block.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/common.proto';
+import 'models/address.proto';
+import 'models/certificate.proto';
+import 'models/transaction.proto';
+
+// Captures a block producer's consensus-commitment to a new block
+message BlockHeader {
+  // The parent block's ID.  Each header builds from a single parent.
+  BlockId parentHeaderId = 1;
+  // The slot of the parent block
+  uint64 parentSlot = 2;
+  // The commitment/accumulator of the block body
+  bytes txRoot = 3;
+  // A fuzzy search for addresses associated with this block
+  bytes bloomFilter = 4;
+  // The UNIX timestamp (ms) when the block was created
+  uint64 timestamp = 5;
+  // The 1-based index of this block in the blockchain
+  uint64 height = 6;
+  // The time-slot in which the block producer is eligible to produce this block
+  uint64 slot = 7;
+  // A certificate indicating that the block producer was eligible to make this block
+  EligibilityCertificate eligibilityCertificate = 8;
+  // A certificate indicating the operator's commitment to this block
+  OperationalCertificate operationalCertificate = 9;
+  // Optional metadata stamped by the operator.  Must be latin-1 encoded, and must be at most 32 bytes in length.
+  optional bytes metadata = 10;
+  // The operator's staking address
+  StakingAddressOperator address = 11;
+}
+
+// Captures the ordering of transaction IDs within a block
+message BlockBody {
+  // A list of Transaction IDs included in this block
+  repeated TransactionId transactionIds = 1;
+}
+
+// Captures the ordering of transactions (not just IDs) within a block
+message FullBlockBody {
+  // A list of Transactions included in this block
+  repeated Transaction transaction = 1;
+}
+
+// Captures the header and all transactions in a block
+message FullBlock {
+  // The block's header
+  BlockHeader header = 1;
+  // The block's full body
+  FullBlockBody fullBody = 2;
+}

--- a/protobuf/models/box.proto
+++ b/protobuf/models/box.proto
@@ -56,14 +56,10 @@ message AssetV1BoxValue {
 
   // An identifier for a collection of Assets
   message Code {
-    // See #ProtoByteComment
-    // TODO: Can we delete this because we know it's a V1 Asset?
-    // The version of the AssetCode (must be `1`)
-    uint32 version = 1;
     // The SpendingAddress of the user/application which minted this Asset.
-    SpendingAddress issuerAddress = 2;
+    SpendingAddress issuerAddress = 1;
     // A name for this Asset.  Must be latin-1 encoded.  Must be at most 8 bytes in length.
-    bytes shortName = 3;
+    bytes shortName = 2;
   }
 }
 // Represents a proof-of-stake registration for an Operator (Block Producer)

--- a/protobuf/models/box.proto
+++ b/protobuf/models/box.proto
@@ -6,7 +6,7 @@ import 'models/common.proto';
 import 'models/address.proto';
 import 'models/proof.proto';
 
-// A synthetic type representing a Transaction Output's value, as well as its spending address evidence
+// A type representing a Transaction Output's value, as well as its spending address evidence.
 message Box {
   // The evidence of the Proposition which locks this Box
   TypedEvidence evidence = 1;

--- a/protobuf/models/box.proto
+++ b/protobuf/models/box.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/common.proto';
+import 'models/address.proto';
+import 'models/proof.proto';
+
+// A synthetic type representing a Transaction Output's value, as well as its spending address evidence
+message Box {
+  // The evidence of the Proposition which locks this Box
+  TypedEvidence evidence = 1;
+  // The value inside of the Box
+  BoxValue value = 2;
+
+  // Represents an identifier or pointer to a Box
+  message Id {
+    TransactionId transactionId = 1;
+    int32 transactionOutputIndex = 2;
+  }
+}
+
+// Captures the value/token/currency/data inside of a Box
+message BoxValue {
+  oneof sealed_value {
+    EmptyBoxValue empty = 1;
+    PolyBoxValue poly = 2;
+    ArbitBoxValue arbit = 3;
+    AssetV1BoxValue assetV1 = 4;
+    OperatorRegistrationBoxValue operatorRegistration = 5;
+  }
+}
+
+// A Box which stores no particular value
+message EmptyBoxValue {}
+// A Box which stores Poly coins
+message PolyBoxValue {
+  // The number of nanopolys
+  Int128 quantity = 1;
+}
+// A Box which stores Arbit coins
+message ArbitBoxValue {
+  // The number of nanoarbits
+  Int128 quantity = 1;
+}
+// A Box which stores Assets (v1)
+message AssetV1BoxValue {
+  // The number of assets
+  Int128 quantity = 1;
+  // The code of this asset
+  Code assetCode = 2;
+  // Optional user/application commitment data.  Strict: 32 bytes
+  bytes securityRoot = 3;
+  // Optional user/application metadata.  Must be latin-1 encoded.  Must be at most 127 bytes in length.
+  optional bytes metadata = 4;
+
+  // An identifier for a collection of Assets
+  message Code {
+    // See #ProtoByteComment
+    // TODO: Can we delete this because we know it's a V1 Asset?
+    // The version of the AssetCode (must be `1`)
+    uint32 version = 1;
+    // The SpendingAddress of the user/application which minted this Asset.
+    SpendingAddress issuerAddress = 2;
+    // A name for this Asset.  Must be latin-1 encoded.  Must be at most 8 bytes in length.
+    bytes shortName = 3;
+  }
+}
+// Represents a proof-of-stake registration for an Operator (Block Producer)
+message OperatorRegistrationBoxValue {
+  ProofKnowledgeKesProduct vrfCommitment = 1;
+}

--- a/protobuf/models/certificate.proto
+++ b/protobuf/models/certificate.proto
@@ -25,6 +25,6 @@ message EligibilityCertificate {
   VerificationKeyVrfEd25519 vrfVK = 2;
   // A 32-byte blake2b256 hash of the operator's `threshold`
   bytes thresholdEvidence = 3;
-  // The epoch's randomness
+  // The epoch's randomness, 32-bytes
   bytes eta = 4;
 }

--- a/protobuf/models/certificate.proto
+++ b/protobuf/models/certificate.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/verification_key.proto';
+import 'models/proof.proto';
+
+// A certificate which commits an operator to a linear key, which is then used to sign the block
+message OperationalCertificate {
+  // The KES VK of the parent key (forward-secure) (hour+minute hands)
+  VerificationKeyKesProduct parentVK = 1;
+  // Signs the `childVK` using the `parentSK`
+  ProofKnowledgeKesProduct parentSignature = 2;
+  // The linear VK
+  VerificationKeyEd25519 childVK = 3;
+  // The signature of the block
+  ProofKnowledgeEd25519 childSignature = 4;
+}
+
+// A certificate proving the operator's election
+message EligibilityCertificate {
+  // Signs `eta ++ slot` using the `vrfSK`
+  ProofKnowledgeVrfEd25519 vrfSig = 1;
+  // The VRF VK
+  VerificationKeyVrfEd25519 vrfVK = 2;
+  // A 32-byte blake2b256 hash of the operator's `threshold`
+  bytes thresholdEvidence = 3;
+  // The epoch's randomness
+  bytes eta = 4;
+}

--- a/protobuf/models/common.proto
+++ b/protobuf/models/common.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+// #ProtoByteComment
+// Protobuf does not support `byte` types, so we use uint32 instead
+
+// A byte indicating a specific network
+message NetworkPrefix {
+  // See #ProtoByteComment
+  uint32 value = 1;
+}
+
+// A hash with a byte prefix indicating the data type of the original value
+message TypedEvidence {
+  // See #ProtoByteComment
+  // A 1-byte discriminator of the original value type
+  uint32 typePrefix = 1;
+  // A blake2b256 32-byte hash of the original value
+  bytes evidence = 2;
+}
+
+// An identifier of a Block
+message BlockId {
+  // A 32-byte blake2b256 hash
+  bytes value = 1;
+}
+
+// An identifier of a Transaction
+message TransactionId {
+  // A 32-byte blake2b256 hash
+  bytes value = 1;
+}
+
+// TODO: Does this representation need to change?
+// Represents a 128-bit integer
+message Int128 {
+  // BigInt Representation
+  bytes value = 1;
+}

--- a/protobuf/models/common.proto
+++ b/protobuf/models/common.proto
@@ -35,6 +35,6 @@ message TransactionId {
 // TODO: Does this representation need to change?
 // Represents a 128-bit integer
 message Int128 {
-  // BigInt Representation
+  // Java BigInt Representation: two's-complement, big-endian
   bytes value = 1;
 }

--- a/protobuf/models/proof.proto
+++ b/protobuf/models/proof.proto
@@ -1,0 +1,104 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/verification_key.proto';
+
+// Represents an argument which satisfies a Proposition
+message Proof {
+  oneof sealed_value {
+    ProofUndefined undefined = 1;
+
+    ProofKnowledgeCurve25519 knowledgeCurve25519 = 2;
+    ProofKnowledgeEd25519 knowledgeEd25519 = 3;
+    ProofKnowledgeVrfEd25519 knowledgeVrfEd25519 = 4;
+    ProofKnowledgeKesSum knowledgeKesSum = 5;
+    ProofKnowledgeKesProduct knowledgeKesProduct = 6;
+    ProofKnowledgeHashLock knowledgeHashLock = 7;
+
+    ProofCompositionalThreshold compositionalThreshold = 8;
+    ProofCompositionalAnd compositionalAnd = 9;
+    ProofCompositionalOr compositionalOr = 10;
+    ProofCompositionalNot compositionalNot = 11;
+
+    ProofContextualHeightLock contextualHeightLock = 12;
+    ProofContextualRequiredTransactionIO contextualTransactionIO = 13;
+  }
+}
+
+// A Proof which will always verify to `false`
+message ProofUndefined {}
+
+// A Proof which contains a Curve25519 signature
+message ProofKnowledgeCurve25519 {
+  // The 64-byte signature of the bytes of the Transaction
+  bytes value = 1;
+}
+
+// A Proof which contains an Ed25519 signature
+message ProofKnowledgeEd25519 {
+  // The 64-byte signature of the bytes of the Transaction
+  bytes value = 1;
+}
+
+// A Proof for consensus purposes - not recommended for UTxO spending logic.
+message ProofKnowledgeVrfEd25519 {
+  // The 80-byte signature
+  bytes value = 1;
+}
+
+// A Proof for consensus purposes - not recommended for UTxO spending logic.
+message ProofKnowledgeKesSum {
+  VerificationKeyEd25519 verificationKey = 1;
+  ProofKnowledgeEd25519 signature = 2;
+  // List of 32-byte Arrays
+  repeated bytes witness = 3;
+}
+
+// A Proof for consensus purposes - not recommended for UTxO spending logic.
+message ProofKnowledgeKesProduct {
+  ProofKnowledgeKesSum superSignature = 1;
+  ProofKnowledgeKesSum subSignature = 2;
+  // 32-bytes
+  bytes subRoot = 3;
+}
+
+// A Proof which provides a value that results in a hash equal to the Proposition's
+message ProofKnowledgeHashLock {
+  // The original data that was hashed to create the corresponding Proposition
+  bytes value = 1;
+}
+
+// A Proof which contains a list of sub-proofs which align with the sub-propositions of the Proposition
+message ProofCompositionalThreshold {
+  // The sub-proofs which satisfy the sub-propositions.  There should be the same number of sub-proofs as there are sub-propositions, and they should be in the same order.
+  repeated Proof proofs = 1;
+}
+
+// A Proof which contains two sub-proofs corresponding to the two sub-propositions of the Proposition.
+message ProofCompositionalAnd {
+  // Proof A
+  Proof a = 1;
+  // Proof B
+  Proof b = 2;
+}
+
+// A Proof which contains two sub-proofs corresponding to the two sub-propositions of the Proposition.
+message ProofCompositionalOr {
+  // Proof A
+  Proof a = 1;
+  // Proof B
+  Proof b = 2;
+}
+
+// A Proof which contains a single sub-proof corresponding to the sub-proposition of the Proposition.
+message ProofCompositionalNot {
+  // Proof A
+  Proof a = 1;
+}
+
+// A Proof which is satisfied by the context of the blockchain when the Transaction is included
+message ProofContextualHeightLock {}
+
+// A Proof which is satisfied by the context of the blockchain (and this Transaction) when the Transaction is included
+message ProofContextualRequiredTransactionIO {}

--- a/protobuf/models/proposition.proto
+++ b/protobuf/models/proposition.proto
@@ -54,7 +54,7 @@ message PropositionKnowledgeHashLock {
 // A Proposition that can be satisfied by satisfying a minimum number of sub-propositions.
 message PropositionCompositionalThreshold {
   // The minimum number of sub-propositions that must be satisfied
-  int32 threshold = 1;
+  uint32 threshold = 1;
   // The *set* of available sub-propositions that can be satisfied.  Propositions must be distinct.
   repeated Proposition propositions = 2;
 }

--- a/protobuf/models/proposition.proto
+++ b/protobuf/models/proposition.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/verification_key.proto';
+import 'models/box.proto';
+
+// Captures the logic/script/contract that must be satisfied in order to spend a particular Box
+message Proposition {
+  oneof sealed_value {
+    PropositionPermanentlyLocked permanentlyLocked = 1;
+
+    PropositionKnowledgeCurve25519 knowledgeCurve25519 = 3;
+    PropositionKnowledgeEd25519 knowledgeEd25519 = 4;
+    PropositionKnowledgeExtendedEd25519 knowledgeExtendedEd25519 = 5;
+    PropositionKnowledgeHashLock knowledgeHashLock = 6;
+
+    PropositionCompositionalThreshold compositionalThreshold = 7;
+    PropositionCompositionalAnd compositionalAnd = 8;
+    PropositionCompositionalOr compositionalOr = 9;
+    PropositionCompositionalNot compositionalNot = 10;
+
+    PropositionContextualHeightLock contextualHeightLock = 11;
+    PropositionContextualRequiredTransactionIO contextualTransactionIO = 12;
+  }
+}
+
+// A Proposition that can't be satisfied
+message PropositionPermanentlyLocked {}
+
+// A Proposition that can be satisfied by proving knowledge of a secret key corresponding to the provided Curve25519 verification key
+// @deprecated
+message PropositionKnowledgeCurve25519 {
+  VerificationKeyCurve25519 key = 1;
+}
+
+// A Proposition that can be satisfied by proving knowledge of a secret key corresponding to the provided Ed25519 verification key
+message PropositionKnowledgeEd25519 {
+  VerificationKeyEd25519 key = 1;
+}
+
+// A Proposition that can be satisfied by proving knowledge of a secret key corresponding to the provided ExtendedEd25519 verification key
+message PropositionKnowledgeExtendedEd25519 {
+  VerificationKeyExtendedEd25519 key = 1;
+}
+
+// A Proposition that can be satisfied by knowledge of data that can be hashed to the provided digest.
+// At this time, only 32-byte blake2b256 is supported.
+message PropositionKnowledgeHashLock {
+  // The hashed value.  Must be 32-bytes.
+  bytes valueDigest = 1;
+}
+
+// A Proposition that can be satisfied by satisfying a minimum number of sub-propositions.
+message PropositionCompositionalThreshold {
+  // The minimum number of sub-propositions that must be satisfied
+  int32 threshold = 1;
+  // The *set* of available sub-propositions that can be satisfied.  Propositions must be distinct.
+  repeated Proposition propositions = 2;
+}
+
+// A Proposition that can be satisfied if both sub-propositions are satisfied.
+message PropositionCompositionalAnd {
+  // Proposition A
+  Proposition a = 1;
+  // Proposition B
+  Proposition b = 2;
+}
+
+// A Proposition that can be satisfied if either of the sub-propositions are satisfied.
+message PropositionCompositionalOr {
+  // Proposition A
+  Proposition a = 1;
+  // Proposition B
+  Proposition b = 2;
+}
+
+// A Proposition that can only be satisfied if the sub-proposition verifies to "false".
+message PropositionCompositionalNot {
+  // The sub-proposition
+  Proposition a = 1;
+}
+
+// A Proposition that can only be satisfied once the height of the blockchain reaches a certain value
+message PropositionContextualHeightLock {
+  // The required minimum height of the blockchain
+  uint64 height = 1;
+}
+
+// A Proposition that can be satisfied if the spending Transaction abides by a certain structure and contains certain values
+message PropositionContextualRequiredTransactionIO {
+  // A list of requirements that must be satisfied by the Transaction
+  repeated Requirement requirements = 1;
+
+  // A "match" description for a particular Box
+  message Requirement {
+    // The exact Box to match
+    Box box = 1;
+    // The Box's location within the Transaction
+    BoxLocation location = 2;
+  }
+}
+
+// Represents where a Box should exist within a Transaction
+message BoxLocation {
+  // The 0-based index of the input or output
+  uint32 index = 1;
+  // Either a Transaction.Input or a Transaction.Output
+  IO location = 2;
+  enum IO {
+    INPUT = 0;
+    OUTPUT = 1;
+  }
+}

--- a/protobuf/models/transaction.proto
+++ b/protobuf/models/transaction.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+import 'models/address.proto';
+import 'models/box.proto';
+import 'models/proof.proto';
+import 'models/proposition.proto';
+
+// Represents the destruction and creation of Boxes
+message Transaction {
+  // The list of UTxOs to consume/destroy/spend
+  repeated Input inputs = 1;
+  // The list of new UTxOs to create
+  repeated Output outputs = 2;
+  // Constrains when this Transaction can be included in the blockchain
+  Schedule schedule = 3;
+  // An optional array of latin-1 encoded bytes.  Maximum length: 127
+  optional bytes data = 4;
+
+  // References a box to spend, plus the proof that is authorized to spend it
+  message Input {
+    // The previous box (reference) to spend
+    Box.Id boxId = 1;
+    // The Proposition which unlocks the Box.  Must result in the "spendingAddress" stamped on the referenced UTxO
+    Proposition proposition = 2;
+    // A Proof which satisfies the Proposition of the Box.
+    Proof proof = 3;
+    // The value inside the box being spent
+    BoxValue value = 4;
+  }
+  // A new Box
+  message Output {
+    // The address associated with the Box, including a commitment to a Proposition that unlocks this new Box
+    FullAddress address = 1;
+    // The value of the new Box
+    BoxValue value = 2;
+    // A flag indicating if this Output is being generated from nothing.  For users/applications, only Asset and Registration values are allowed in `value`.
+    bool minting = 3;
+  }
+  // Represents constraints on when a Transaction can be included in the blockchain
+  message Schedule {
+    // A UNIX timestamp (ms) of the transaction's original creation.  User-defined with no impact on the protocol.  Must be positive.
+    uint64 creation = 1;
+    // The minimum slot number of the block containing this transaction
+    uint64 minimumSlot = 2;
+    // The maximum slot number of the block constraing this transaction.  Must be greater than `minimumSlot`.
+    uint64 maximumSlot = 3;
+  }
+}

--- a/protobuf/models/verification_key.proto
+++ b/protobuf/models/verification_key.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package co.topl.proto.models;
+
+// A key that can be shared publicly and is used to verify a digital signature
+message VerificationKey {
+  oneof sealed_value {
+    VerificationKeyCurve25519 curve25519 = 1;
+    VerificationKeyEd25519 ed25519 = 2;
+    VerificationKeyExtendedEd25519 extendedEd25519 = 3;
+    VerificationKeyVrfEd25519 vrfEd25519 = 4;
+    VerificationKeyKesProduct kesProduct = 5;
+  }
+}
+
+// A Curve25519 Verification Key
+message VerificationKeyCurve25519 {
+  // Strict: 32 bytes
+  bytes value = 1;
+}
+
+// An Ed25519 Verification Key
+message VerificationKeyEd25519 {
+  // Strict: 32 bytes
+  bytes value = 1;
+}
+
+// An ExtendedEd25519 Verification Key
+message VerificationKeyExtendedEd25519 {
+  VerificationKeyEd25519 vk = 1;
+  // Strict: 32 bytes
+  bytes chainCode = 2;
+}
+
+// For consensus purposes - not recommended for users/applications
+message VerificationKeyVrfEd25519 {
+  // Strict: 32 bytes
+  bytes value = 1;
+}
+
+// For consensus purposes - not recommended for users/applications
+message VerificationKeyKesProduct {
+  // Strict: 32 bytes
+  bytes value = 1;
+  int32 step = 2;
+}


### PR DESCRIPTION
# Purpose
- Specifies the initial set of proto definitions within the Topl ecosystem

# Approach
- Imports the initial set of .proto definitions from the [Bifrost repo](https://github.com/Topl/Bifrost/tree/tetra/topl-grpc/src/main/protobuf)
- Added documentation/comments

# Note
These definitions are preliminary and are expected to change in the near future.  We will eagerly include the current definitions in `main` to allow for linking/URLs during conversations/planning.