### PR TITLE
Remove "optional" Syntax

### DIFF
--- a/genus/genus_models.proto
+++ b/genus/genus_models.proto
@@ -88,7 +88,8 @@ message IndexSpec {
   // A description of the fields to be indexed
   IndexFieldSpec indexFieldSpec = 3;
   // Filter to determine which transactions are included in the index. Only records that match the filter will be included in the index.
-  optional IndexFilter indexFilter = 4;
+  // optional
+  IndexFilter indexFilter = 4;
 }
 
 // A specification to identify the field(s) in data to be indexed
@@ -104,7 +105,8 @@ message IndexFieldSpec {
 message CsvIndexSpecs {
   repeated CsvIndexSpec specs = 1;
   uint32 separatorChar = 2; // The character code that is used to separate fields.
-  optional uint32 quoteChar = 4; // If this is present, the specified character appears at the beginning and end of each field.
+  // optional
+  uint32 quoteChar = 4; // If this is present, the specified character appears at the beginning and end of each field.
 }
 
 // a sequence of csv field references to identify the values in data to be indexed

--- a/genus/genus_rpc.proto
+++ b/genus/genus_rpc.proto
@@ -110,24 +110,28 @@ message TxoResponse {
 
 message GetBlockByIdRequest {
   models.BlockId blockId = 1;
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 message GetBlockByHeightRequest {
   ChainDistance height = 1;
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 message GetBlockByDepthRequest {
   ChainDistance depth = 1;
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 // Used to request a transaction by specifying its ID.
 message GetTransactionByIdRequest {
   models.TransactionId transactionId = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 // Response from CreateOnChainTransactionIndex request
@@ -141,14 +145,16 @@ message QueryByAddressRequest {
   // All the addresses of interest
   repeated models.SpendingAddress addresses = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 // User to request TxOs by their asset type
 message QueryByAssetLabelRequest {
   AssetLabel assetLabel = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
-  optional ConfidenceFactor confidenceFactor = 2;
+  // optional
+  ConfidenceFactor confidenceFactor = 2;
 }
 
 message TxoAddressResponse {
@@ -202,10 +208,12 @@ message GetIndexedTransactionsRequest {
   repeated IndexMatchValue value = 2;
 
   // The maximum number of transactions to be returned
-  optional uint32 maxResults = 3;
+  // optional
+  uint32 maxResults = 3;
 
   // A number of transactions to be skipped. This is useful for paging results.
-  optional uint64 skipResults = 4;
+  // optional
+  uint64 skipResults = 4;
 }
 
 // A value that may match a field in an index.
@@ -215,7 +223,8 @@ message IndexMatchValue {
     int64 intValue = 2;
     uint64 uintValue = 3;
   }
-  optional string fieldName = 4;
+  // optional
+  string fieldName = 4;
 }
 
 //service SubscriptionService {

--- a/models/block.proto
+++ b/models/block.proto
@@ -28,7 +28,7 @@ message BlockHeader {
   // A certificate indicating the operator's commitment to this block
   OperationalCertificate operationalCertificate = 9;
   // Optional metadata stamped by the operator.  Must be latin-1 encoded, and must be at most 32 bytes in length.
-  optional bytes metadata = 10;
+  bytes metadata = 10;
   // The operator's staking address
   StakingAddressOperator address = 11;
 }

--- a/models/block.proto
+++ b/models/block.proto
@@ -28,6 +28,7 @@ message BlockHeader {
   // A certificate indicating the operator's commitment to this block
   OperationalCertificate operationalCertificate = 9;
   // Optional metadata stamped by the operator.  Must be latin-1 encoded, and must be at most 32 bytes in length.
+  // optional
   bytes metadata = 10;
   // The operator's staking address
   StakingAddressOperator address = 11;

--- a/models/box.proto
+++ b/models/box.proto
@@ -52,7 +52,7 @@ message AssetV1BoxValue {
   // Optional user/application commitment data.  Strict: 32 bytes
   bytes securityRoot = 3;
   // Optional user/application metadata.  Must be latin-1 encoded.  Must be at most 127 bytes in length.
-  optional bytes metadata = 4;
+  bytes metadata = 4;
 
   // An identifier for a collection of Assets
   message Code {

--- a/models/box.proto
+++ b/models/box.proto
@@ -52,6 +52,7 @@ message AssetV1BoxValue {
   // Optional user/application commitment data.  Strict: 32 bytes
   bytes securityRoot = 3;
   // Optional user/application metadata.  Must be latin-1 encoded.  Must be at most 127 bytes in length.
+  // optional
   bytes metadata = 4;
 
   // An identifier for a collection of Assets

--- a/models/transaction.proto
+++ b/models/transaction.proto
@@ -16,6 +16,7 @@ message Transaction {
   // Constrains when this Transaction can be included in the blockchain
   Schedule schedule = 3;
   // An optional array of bytes.
+  // optional
   bytes data = 4;
 
   // References a box to spend, plus the proof that is authorized to spend it

--- a/models/transaction.proto
+++ b/models/transaction.proto
@@ -16,7 +16,7 @@ message Transaction {
   // Constrains when this Transaction can be included in the blockchain
   Schedule schedule = 3;
   // An optional array of bytes.
-  optional bytes data = 4;
+  bytes data = 4;
 
   // References a box to spend, plus the proof that is authorized to spend it
   message Input {
@@ -37,7 +37,8 @@ message Transaction {
     BoxValue value = 2;
     // Minting
     bool minting = 3;
-    optional bytes metadata = 4;
+    // optional
+    bytes metadata = 4;
   }
 
   // Represents constraints on when a Transaction can be included in the blockchain

--- a/node/bifrost_rpc.proto
+++ b/node/bifrost_rpc.proto
@@ -59,7 +59,8 @@ message FetchBlockHeaderReq {
 // Response type for FetchBlockHeader
 message FetchBlockHeaderRes {
   // The Block Header associated with the requested ID.  None/null if not found.
-  optional co.topl.proto.models.BlockHeader header = 1;
+  // optional
+  co.topl.proto.models.BlockHeader header = 1;
 }
 
 // Request type for FetchBlockBody
@@ -71,7 +72,8 @@ message FetchBlockBodyReq {
 // Response type for FetchBlockBody
 message FetchBlockBodyRes {
   // The Block Body associated with the requested ID.  None/null if not found.
-  optional co.topl.proto.models.BlockBody body = 1;
+  // optional
+  co.topl.proto.models.BlockBody body = 1;
 }
 
 // Request type for FetchTransaction
@@ -82,7 +84,8 @@ message FetchTransactionReq {
 // Response type for FetchTransaction
 message FetchTransactionRes {
   // The Transaction associated with the requested ID.  None/null if not found.
-  optional co.topl.proto.models.Transaction transaction = 1;
+  // optional
+  co.topl.proto.models.Transaction transaction = 1;
 }
 
 // Request type for FetchBlockIdAtHeight
@@ -94,7 +97,8 @@ message FetchBlockIdAtHeightReq {
 // Response type for FetchBlockIdAtHeight
 message FetchBlockIdAtHeightRes {
   // The Block ID associated with the requested height.  None/null if not found.
-  optional co.topl.proto.models.BlockId blockId = 1;
+  // optional
+  co.topl.proto.models.BlockId blockId = 1;
 }
 
 // Request type for FetchBlockIdAtDepth
@@ -106,7 +110,8 @@ message FetchBlockIdAtDepthReq {
 // Response type for FetchBlockIdAtDepth
 message FetchBlockIdAtDepthRes {
   // The Block ID associated with the requested depth.  None/null if not found.
-  optional co.topl.proto.models.BlockId blockId = 1;
+  // optional
+  co.topl.proto.models.BlockId blockId = 1;
 }
 
 // Request type for SynchronizationTraversal

--- a/run_protocol_compilers.sh
+++ b/run_protocol_compilers.sh
@@ -7,5 +7,4 @@ mkdir generated/python 2>>log
 # --experimental_allow_proto3_optional
 # ➜  protobuf-specs git:(main) ✗ protoc --version -> libprotoc 3.12.4
 
-protoc --experimental_allow_proto3_optional --python_out=generated/python --java_out=generated/java node/bifrost_rpc.proto genus/genus_rpc.proto
-
+protoc --python_out=generated/python --java_out=generated/java node/bifrost_rpc.proto genus/genus_rpc.proto


### PR DESCRIPTION
## Purpose
- `optional` proto3 syntax is experimental and not supported in all target languages
- `optional` proto3 syntax does not modify behavior anyway; it's mostly just a documentation syntax
## Approach
- Remove uses of `optional` syntax, replace with a comment
## Testing
N/A
## Tickets
N/A