### PR TITLE
Add Crypto Models

### DIFF
--- a/crypto/models/ed25519.proto
+++ b/crypto/models/ed25519.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package co.topl.crypto.models;
+
+// A semi-public verification key using Ed25519
+message VerificationKeyEd25519 {
+    // The bytes of the key
+    // length = 32
+    bytes value = 1;
+}
+
+// A privately-held secret key using Ed25519
+message SecretKeyEd25519 {
+    // The bytes of the key
+    // length = 32
+    bytes value = 1;
+}
+
+// A signature generated using Ed25519
+message SignatureEd25519 {
+    // The bytes of the signature
+    // length = 64
+    bytes value = 1;
+}

--- a/node/models/certificate.proto
+++ b/node/models/certificate.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package co.topl.node.models;
+
+import 'crypto/models/ed25519.proto';
+import 'node/models/kes.proto';
+import 'node/models/vrf.proto';
+
+// A certificate which commits an operator to a linear key, which is then used to sign the block
+message OperationalCertificate {
+  // The KES VK of the parent key (forward-secure) (hour+minute hands)
+  VerificationKeyKesProduct parentVK = 1;
+  // Signs the `childVK` using the `parentSK`
+  SignatureKesProduct parentSignature = 2;
+  // The linear VK
+  co.topl.crypto.models.VerificationKeyEd25519 childVK = 3;
+  // The signature of the block
+  co.topl.crypto.models.SignatureEd25519 childSignature = 4;
+}
+
+// A certificate proving the operator's election
+message EligibilityCertificate {
+  // Signs `eta ++ slot` using the `vrfSK`
+  SignatureVrfEd25519 vrfSig = 1;
+  // The VRF VK
+  VerificationKeyVrfEd25519 vrfVK = 2;
+  // A 32-byte blake2b256 hash of the operator's `threshold`
+  bytes thresholdEvidence = 3;
+  // The epoch's randomness, 32-bytes
+  bytes eta = 4;
+}

--- a/node/models/certificate.proto
+++ b/node/models/certificate.proto
@@ -24,8 +24,11 @@ message EligibilityCertificate {
   SignatureVrfEd25519 vrfSig = 1;
   // The VRF VK
   VerificationKeyVrfEd25519 vrfVK = 2;
-  // A 32-byte blake2b256 hash of the operator's `threshold`
+  // Hash of the operator's `threshold`
+  // routine = blake2b256
+  // length = 32
   bytes thresholdEvidence = 3;
-  // The epoch's randomness, 32-bytes
+  // The epoch's randomness
+  // length = 32
   bytes eta = 4;
 }

--- a/node/models/kes.proto
+++ b/node/models/kes.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package co.topl.node.models;
+
+import 'crypto/models/ed25519.proto';
+
+message VerificationKeyKesSum {
+    // length = 32
+    bytes value = 1;
+    uint32 step = 2;
+}
+
+message VerificationKeyKesProduct {
+    // length = 32
+    bytes value = 1;
+    uint32 step = 2;
+}
+
+message SecretKeyKesSum {
+    KesBinaryTree tree = 1;
+    uint64 offset = 2;
+}
+
+message SecretKeyKesProduct {
+    KesBinaryTree superTree = 1;
+    KesBinaryTree subTree = 2;
+    // length = 32 TODO
+    bytes nextSubSeed = 3;
+    SignatureKesSum subSignature = 4;
+    uint64 offset = 5;
+}
+
+message SignatureKesSum {
+    co.topl.crypto.models.VerificationKeyEd25519 verificationKey = 1;
+    co.topl.crypto.models.SignatureEd25519 signature = 2;
+    // item length = 32
+    repeated bytes witness = 3;
+}
+
+message SignatureKesProduct {
+    SignatureKesSum superSignature = 1;
+    SignatureKesSum subSignature = 2;
+    // length = 32
+    bytes subRoot = 3;
+}
+
+message KesBinaryTree {
+    oneof value {
+        KesBinaryTreeMerkleNode merkleNode = 1;
+        KesBinaryTreeSigningLeaf signingLeaf = 2;
+        KesBinaryTreeEmpty empty = 3;
+    }
+}
+
+message KesBinaryTreeMerkleNode {
+    bytes seed = 1;
+    bytes witnessLeft = 2;
+    bytes witnessRight = 3;
+    KesBinaryTree left = 4;
+    KesBinaryTree right = 5;
+}
+
+message KesBinaryTreeSigningLeaf {
+    bytes sk = 1;
+    bytes vk = 2;
+}
+
+message KesBinaryTreeEmpty {}

--- a/node/models/kes.proto
+++ b/node/models/kes.proto
@@ -53,15 +53,20 @@ message KesBinaryTree {
 }
 
 message KesBinaryTreeMerkleNode {
+    // length = 32
     bytes seed = 1;
+    // length = 32
     bytes witnessLeft = 2;
+    // length = 32
     bytes witnessRight = 3;
     KesBinaryTree left = 4;
     KesBinaryTree right = 5;
 }
 
 message KesBinaryTreeSigningLeaf {
+    // length = 32
     bytes sk = 1;
+    // length = 32
     bytes vk = 2;
 }
 

--- a/node/models/vrf.proto
+++ b/node/models/vrf.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package co.topl.node.models;
+
+message VerificationKeyVrfEd25519 {
+    // length = 32
+    bytes value = 1;
+}
+
+message SecretKeyVrfEd25519 {
+    // length = 32
+    bytes value = 1;
+}
+
+message SignatureVrfEd25519 {
+    // length = 80
+    bytes value = 1;
+}


### PR DESCRIPTION
## Purpose
- Cryptographic signing routines need Verification Keys, Secret Keys, and Signatures.  These can be captured as types.
- The node uses some additional cryptographic routines that have different structures
## Approach
- Define a `crypto` "module".  Add `ed25519` models.
- Add KES and VRFEd25519 definitions to the `node` "module"
## Testing
- run_proto_compilers.sh
## Tickets
- BN-718