### PR TITLE
Scala FlatPackage

### DIFF
--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -66,6 +66,7 @@ lazy val protobufFs2 =
       publishSettings,
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
       buildInfoPackage := "co.topl.buildinfo.protobuffs2",
+      scalapbCodeGeneratorOptions += CodeGeneratorOption.FlatPackage,
       // This task copies all .proto files from the repository root into a directory that can be referenced by ScalaPB
       copyProtobufTask := {
         import java.nio.file._

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,4 +2,3 @@ jdk:
   - openjdk11
 install:
   - cd build/scala && sbt publishM2
-


### PR DESCRIPTION
## Purpose
- ScalaPB has a code generator option which flattens out all message definitions into its declared package scope instead of further nesting by file name
  - (This option was used in Bifrost but was not carried over here to protobuf-specs)
## Approach
- Added the option
## Testing
N/A
## Tickets
N/A
