### PR TITLE
TSDK-223 Added models from the brambl layer in Quivr4s

### DIFF
--- a/brambl/models/indices.proto
+++ b/brambl/models/indices.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package co.topl.brambl.models;
+
+message Indices {
+    uint32 x = 1;
+    uint32 y = 2;
+    uint32 z = 3;
+}

--- a/quivr/models/shared.proto
+++ b/quivr/models/shared.proto
@@ -49,6 +49,15 @@ message VerificationKey {
     bytes value = 1;
 }
 
+message SigningKey {
+    bytes value = 1;
+}
+
+message KeyPair{
+    VerificationKey vk = 1;
+    SigningKey sk = 2;
+}
+
 message Message {
     bytes value = 1;
 }


### PR DESCRIPTION
## Purpose

To move models that are used in the brambl package within quivr4s to PB. 

## Approach

I put SigningKey and KeyPair in the quivr layer because I thought it would be helpful to keep them with VerificationKey. However, I believe they will only be used in brambl so I am not opposed to moving them.

## Testing
* Ran `cd build/scala` and `sbt publishLocal` => local build successful
* After pushing, I used JitPack in my local quivr4s branch to consume these models

## Tickets
* Related to #TSDK-221 
* Partial PR of #TSDK-223
