### PR TITLE
TSDK-223 Added new models used by the brambl builders

### DIFF
--- a/brambl/models/builders.proto
+++ b/brambl/models/builders.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package co.topl.brambl.models.builders;
+
+import 'quivr/models/shared.proto';
+import 'brambl/models/known_identifier.proto';
+import 'brambl/models/box/lock.proto';
+import 'brambl/models/box/value.proto';
+
+
+// Data required to build a transaction output (UnspentTransactionOutput)
+message OutputBuildRequest{
+  co.topl.brambl.models.box.Lock lock = 1;
+  co.topl.brambl.models.box.Value value = 2;
+  quivr.models.SmallData metadata = 3;
+}
+
+// Data required to build a transaction input (SpentTransactionOutput)
+message InputBuildRequest{
+  co.topl.brambl.models.KnownIdentifier id = 1;
+  quivr.models.SmallData metadata = 2;
+}


### PR DESCRIPTION
## Purpose

During the creation of brambl builders in TSDK-221, 2 new models were introduced. This PR is to move them to PB

## Approach

Put OutputBuildRequest and InputBuildRequest under brambl.models.builders with a comment explaining each

## Testing

- Ran `cd build/scala` and `sbt publishLocal` => local build successful
- After pushing, I used JitPack in my local quivr4s branch to consume these models

## Tickets
* Related to #TSDK-221
* Closes #TSDK-223