### PR TITLE
SBT Publish protobuf-specs Sources

### DIFF
--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -103,5 +103,12 @@ lazy val protobufFs2 =
       },
       (Compile / compile) := (Compile / compile).dependsOn(copyProtobufTask).value,
       // Consume the copied files from the task above
-      Compile / PB.protoSources := Seq(new java.io.File(s"${(Compile / target).value.toString}/protobuf-tmp"))
+      Compile / PB.protoSources := Seq(new java.io.File(s"${(Compile / target).value.toString}/protobuf-tmp")),
+      // By default, "managed sources" (the generated protobuf scala files) do not publish their source code,
+      // so this step includes generated sources in the published package
+      Compile / packageSrc / mappings ++= {
+        val base = (Compile / sourceManaged).value
+        val files = (Compile / managedSources).value
+        files.map { f => (f, f.relativeTo(base).get.getPath) }
+      }
     )


### PR DESCRIPTION
## Purpose
- SBT includes the original source code with the compiled code by default when publishing its artifacts
  - But it does **not** include _generated_ source code, for example, code generated by `protoc`
## Approach
- Add generated source code to the published artifact
## Testing
- Checked locally in the Bifrost repository:
  ![image](https://user-images.githubusercontent.com/2218886/213753570-bd200eb4-d51b-4e57-ac94-59bf14a2a127.png)

## Tickets
N/A