### PR TITLE
BN-820-Protobuf-Specs-OperationalCertificate-Len-Rule

### DIFF
--- a/proto/consensus/models/block_id.proto
+++ b/proto/consensus/models/block_id.proto
@@ -2,7 +2,9 @@ syntax = "proto3";
 
 package co.topl.consensus.models;
 
+import "validate/validate.proto";
+
 message BlockId {
     // length = 32
-    bytes value = 1;
+    bytes value = 1 [(validate.rules).bytes.len = 32];
 }


### PR DESCRIPTION
## Purpose
Add length rule

## Approach

> bytes value = 1 [(validate.rules).bytes.len = 32];

## Testing
Generated Code:

```
package co.topl.consensus.models

object BlockIdValidator extends scalapb.validate.Validator[co.topl.consensus.models.BlockId] {
  def validate(input: co.topl.consensus.models.BlockId): scalapb.validate.Result =
    scalapb.validate.Result.run(io.envoyproxy.pgv.BytesValidation.length("BlockId.value", input.value, 32))
  
}
```

## Tickets

https://topl.atlassian.net/browse/BN-820
