### PR TITLE
BN-820-Protobuf-Specs-OperationalCertificate-Rules

### DIFF
--- a/proto/consensus/models/operational_certificate.proto
+++ b/proto/consensus/models/operational_certificate.proto
@@ -2,36 +2,56 @@ syntax = "proto3";
 
 package co.topl.consensus.models;
 
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+
 import 'crypto/models/ed25519.proto';
 
 // A certificate which commits an operator to a linear key, which is then used to sign the block
 message OperationalCertificate {
   // The KES VK of the parent key (forward-secure) (hour+minute hands)
-  VerificationKeyKesProduct parentVK = 1;
+  VerificationKeyKesProduct parentVK = 1 [(validate.rules).message.required = true];
   // Signs the `childVK` using the `parentSK`
-  SignatureKesProduct parentSignature = 2;
+  SignatureKesProduct parentSignature = 2 [(validate.rules).message.required = true];
   // The linear VK
-  co.topl.crypto.models.VerificationKeyEd25519 childVK = 3;
+  co.topl.crypto.models.VerificationKeyEd25519 childVK = 3 [(validate.rules).message.required = true];
   // The signature of the block
-  co.topl.crypto.models.SignatureEd25519 childSignature = 4;
+  co.topl.crypto.models.SignatureEd25519 childSignature = 4 [(validate.rules).message.required = true];
 }
 
 message VerificationKeyKesProduct {
     // length = 32
-    bytes value = 1;
+    bytes value = 1 [(validate.rules).bytes.len = 32];
     uint32 step = 2;
 }
 
 message SignatureKesSum {
-    co.topl.crypto.models.VerificationKeyEd25519 verificationKey = 1;
-    co.topl.crypto.models.SignatureEd25519 signature = 2;
+    co.topl.crypto.models.VerificationKeyEd25519 verificationKey = 1 [(validate.rules).message.required = true];
+    co.topl.crypto.models.SignatureEd25519 signature = 2 [(validate.rules).message.required = true];
     // item length = 32
-    repeated bytes witness = 3;
+    repeated bytes witness = 3 [(validate.rules).repeated.items.bytes.len = 32];
 }
 
 message SignatureKesProduct {
-    SignatureKesSum superSignature = 1;
-    SignatureKesSum subSignature = 2;
+    SignatureKesSum superSignature = 1 [(validate.rules).message.required = true];
+    SignatureKesSum subSignature = 2 [(validate.rules).message.required = true];
     // length = 32
-    bytes subRoot = 3;
+    bytes subRoot = 3 [(validate.rules).bytes.len = 32];
 }
+
+option (scalapb.options) = {
+  [scalapb.validate.file] {
+    validate_at_construction: true
+  }
+  field_transformations: [
+    {
+      when: {options: {[validate.rules] {message: {required: true}}}}
+      set: {
+        [scalapb.field] {
+          required: true
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## Purpose
Protobuf-Specs-OperationalCertificate-Rules
## Approach

- required and lengths rules
## Testing

```
final case class OperationalCertificate(
    parentVK: co.topl.consensus.models.VerificationKeyKesProduct,
    parentSignature: co.topl.consensus.models.SignatureKesProduct,
    childVK: co.topl.crypto.models.VerificationKeyEd25519,
    childSignature: co.topl.crypto.models.SignatureEd25519,
```


```
object SignatureKesProductValidator extends scalapb.validate.Validator[co.topl.consensus.models.SignatureKesProduct] {
  def validate(input: co.topl.consensus.models.SignatureKesProduct): scalapb.validate.Result =
    co.topl.consensus.models.SignatureKesSumValidator.validate(input.superSignature) &&
    co.topl.consensus.models.SignatureKesSumValidator.validate(input.subSignature) &&
    scalapb.validate.Result.run(io.envoyproxy.pgv.BytesValidation.length("SignatureKesProduct.subRoot", input.subRoot, 32))
  
}
```



  ```
  scalapb.validate.Result.repeated(input.witness.iterator) { _value =>
      scalapb.validate.Result.run(io.envoyproxy.pgv.BytesValidation.length("SignatureKesSum.witness", _value, 32))
    }

```
## Tickets
https://topl.atlassian.net/browse/BN-820