### PR TITLE
Added ImmutableBytes definition

### DIFF
--- a/proto/brambl/models/common.proto
+++ b/proto/brambl/models/common.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package co.topl.brambl.models.common;
+
+// Immutable byte representation of a value
+message ImmutableBytes {
+  bytes value = 1;
+}


### PR DESCRIPTION
## Purpose

Add model to encapsulate ImmutableBytes

## Approach

Added ImmutableBytes in the Brambl layer to mirror the  [SignableBytes](https://github.com/Topl/protobuf-specs/blob/main/proto/quivr/models/shared.proto#L75) in the quivr layer. 

## Testing
- Ran `cd build.scala` and `sbt publishLocal` and verified library built as expected with new model

## Tickets
* Part of TSDK-287