### PR TITLE
blockheader rules

### DIFF
--- a/proto/consensus/models/block_header.proto
+++ b/proto/consensus/models/block_header.proto
@@ -18,9 +18,11 @@ message BlockHeader {
   // The slot of the parent block
   uint64 parentSlot = 2;
   // The commitment/accumulator of the block body
-  bytes txRoot = 3;
+  // length = 32
+  bytes txRoot = 3 [(validate.rules).bytes.len = 32];
   // A fuzzy search for addresses associated with this block
-  bytes bloomFilter = 4;
+  // length = 256
+  bytes bloomFilter = 4[(validate.rules).bytes.len = 256];
   // The UTC UNIX timestamp (ms) when the block was created
   uint64 timestamp = 5;
   // The 1-based index of this block in the blockchain
@@ -33,7 +35,7 @@ message BlockHeader {
   OperationalCertificate operationalCertificate = 9 [(validate.rules).message.required = true];
   // Optional metadata stamped by the operator.  Must be latin-1 encoded, and must be at most 32 bytes in length.
   // optional
-  bytes metadata = 10;
+  bytes metadata = 10 [(validate.rules).bytes.max_len = 32];
   // The operator's staking address
   // length = 32
   bytes address = 11 [(validate.rules).bytes.len = 32];

--- a/proto/consensus/models/block_header.proto
+++ b/proto/consensus/models/block_header.proto
@@ -6,11 +6,15 @@ import 'consensus/models/block_id.proto';
 import 'consensus/models/eligibility_certificate.proto';
 import 'consensus/models/operational_certificate.proto';
 
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+
 // Captures a block producer's consensus-commitment to a new block
 message BlockHeader {
   // The parent block's ID.  Each header builds from a single parent.
   // length = 32
-  BlockId parentHeaderId = 1;
+  BlockId parentHeaderId = 1 [(validate.rules).message.required = true];
   // The slot of the parent block
   uint64 parentSlot = 2;
   // The commitment/accumulator of the block body
@@ -24,13 +28,29 @@ message BlockHeader {
   // The time-slot in which the block producer created the block
   uint64 slot = 7;
   // A certificate indicating that the block producer was eligible to make this block
-  EligibilityCertificate eligibilityCertificate = 8;
+  EligibilityCertificate eligibilityCertificate = 8 [(validate.rules).message.required = true];
   // A certificate indicating the operator's commitment to this block
-  OperationalCertificate operationalCertificate = 9;
+  OperationalCertificate operationalCertificate = 9 [(validate.rules).message.required = true];
   // Optional metadata stamped by the operator.  Must be latin-1 encoded, and must be at most 32 bytes in length.
   // optional
   bytes metadata = 10;
   // The operator's staking address
   // length = 32
-  bytes address = 11;
+  bytes address = 11 [(validate.rules).bytes.len = 32];
 }
+
+option (scalapb.options) = {
+  [scalapb.validate.file] {
+    validate_at_construction: true
+  }
+  field_transformations: [
+    {
+      when: {options: {[validate.rules] {message: {required: true}}}}
+      set: {
+        [scalapb.field] {
+          required: true
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## Purpose
blockheader rules
## Approach

## Testing
```scala
package co.topl.consensus.models

object BlockHeaderValidator extends scalapb.validate.Validator[co.topl.consensus.models.BlockHeader] {
  def validate(input: co.topl.consensus.models.BlockHeader): scalapb.validate.Result =
    co.topl.consensus.models.BlockIdValidator.validate(input.parentHeaderId) &&
    co.topl.consensus.models.EligibilityCertificateValidator.validate(input.eligibilityCertificate) &&
    co.topl.consensus.models.OperationalCertificateValidator.validate(input.operationalCertificate) &&
    scalapb.validate.Result.run(io.envoyproxy.pgv.BytesValidation.length("BlockHeader.address", input.address, 32))
  
}
```


## Tickets
* closes https://topl.atlassian.net/browse/BN-829