### PR TITLE
TSDK-319 | Genus protobuf migration

### DIFF
--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -5,11 +5,15 @@ syntax = "proto3";
 ///////////////////////////////////////////////////////////////////////////////
 
 import 'models/address.proto';
-import 'models/box.proto';
+import 'brambl/models/address.proto';
+import 'brambl/models/box/box.proto';
+import 'brambl/models/known_identifier.proto';
+import 'brambl/models/transaction/io_transaction.proto';
+import 'consensus/models/block_id.proto';
 import 'models/common.proto';
 import 'models/transaction.proto';
 
-package co.topl.proto.genus;
+package co.topl.genus.services;
 
 // Used to identify the status of a box.
 enum TxoState {
@@ -20,10 +24,10 @@ enum TxoState {
 
 // A Box and its status
 message Txo {
-  models.Box box = 1;
+  brambl.models.box.Box box = 1;
   TxoState state = 2;
-  models.Box.Id id = 3;
-  models.SpendingAddress address = 4;
+  brambl.models.KnownIdentifier.TransactionOutput32 id = 3;
+  brambl.models.Address address = 4;
 }
 
 // Specify the order of data for indexes.
@@ -66,7 +70,7 @@ message AssetLabel {
 
   message V1Label {
     uint32 version = 1;
-    models.SpendingAddress mintingAddress = 2;
+    brambl.models.Address mintingAddress = 2;
   }
 
   message Tam2Label {
@@ -136,8 +140,8 @@ message IndexFilter {
 }
 
 message TransactionReceipt {
-  models.Transaction transaction = 1;
+  brambl.models.transaction.IoTransaction transaction = 1;
   ConfidenceFactor confidenceFactor = 2;
-  models.BlockId blockId = 3;
+  consensus.models.BlockId blockId = 3;
   ChainDistance depth = 4;
 }

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -4,12 +4,13 @@ syntax = "proto3";
 // Services provided by Genus
 ///////////////////////////////////////////////////////////////////////////////
 
-package co.topl.proto.genus;
+package co.topl.genus.services;
 
-import 'models/address.proto';
-import 'models/block.proto';
-import 'models/common.proto';
+import 'brambl/models/address.proto';
+import 'brambl/models/identifier.proto';
+import 'consensus/models/block_id.proto';
 import 'genus/genus_models.proto';
+import 'node/models/block.proto';
 
 // Operations related to blocks
 service GenusFullBlockService {
@@ -97,7 +98,7 @@ message GetExistingTransactionIndexesResponse {
 }
 
 message BlockResponse {
-  models.FullBlock block = 1;
+  node.models.FullBlock block = 1;
 }
 
 message TransactionResponse {
@@ -109,7 +110,7 @@ message TxoResponse {
 }
 
 message GetBlockByIdRequest {
-  models.BlockId blockId = 1;
+  consensus.models.BlockId blockId = 1;
   // optional
   ConfidenceFactor confidenceFactor = 2;
 }
@@ -128,7 +129,7 @@ message GetBlockByDepthRequest {
 
 // Used to request a transaction by specifying its ID.
 message GetTransactionByIdRequest {
-  models.TransactionId transactionId = 1;
+  brambl.models.Identifier.IoTransaction32 transactionId = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   // optional
   ConfidenceFactor confidenceFactor = 2;
@@ -143,7 +144,7 @@ message CreateOnChainTransactionIndexResponse {
 // Used to request TxOs by their associated address
 message QueryByAddressRequest {
   // All the addresses of interest
-  repeated models.SpendingAddress addresses = 1;
+  repeated brambl.models.Address addresses = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   // optional
   ConfidenceFactor confidenceFactor = 2;
@@ -162,7 +163,7 @@ message TxoAddressResponse {
   map<string, Txo> addressesToTxos = 1;
 
   message Txos {
-    repeated genus.Txo txo = 1;
+    repeated genus.services.Txo txo = 1;
   }
 }
 


### PR DESCRIPTION
## Purpose
Protobuf specs are currently using the older models, which should be replaced by the new ones.

## Approach
- Updated genus_rpc.proto
- Updated genus_models.proto

## Testing
Protobuf compiler runs correctly and the project structure looks correct.

## Tickets
* TSDK-319