### PR TITLE
Add node models Block contraints validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Node models: Block, and FullBlockBody constraints validations. [TODO: commit]
 
 ### Changed[c920f90]
 - Consensus OperationalCertificate includes VerificationKeyEd25519, SecretKeyEd25519, SignatureEd25519 with constraints validations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Changed[c920f90]
+- Consensus OperationalCertificate includes VerificationKeyEd25519, SecretKeyEd25519, SignatureEd25519 with constraints validations.
+
+### Changed[53c5f3a]
+- Node services Rpc constraints validations.
+
+### Changed[f2b8a87]
+- Added the required PB scala validation rules to some IoTransaction models
+- Added scala PB validation rules to all brambl models
+
+### Changed[948dc20]
+- Consensus Block Header constraints validations
+
+### Changed[437d117]
+- Consensus SlotData constraints validations
+
 ### Changed
 - Moved Topl domain protos to `proto` directory
 

--- a/proto/node/models/block.proto
+++ b/proto/node/models/block.proto
@@ -6,6 +6,10 @@ import 'consensus/models/block_header.proto';
 import 'brambl/models/transaction/io_transaction.proto';
 import 'brambl/models/identifier.proto';
 
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+
 // Captures the ordering of transaction IDs within a block
 message BlockBody {
   // A list of Transaction IDs included in this block
@@ -21,15 +25,31 @@ message FullBlockBody {
 // Captures the header and all transactions in a block
 message Block {
   // The block's header
-  co.topl.consensus.models.BlockHeader header = 1;
+  co.topl.consensus.models.BlockHeader header = 1 [(validate.rules).message.required = true];
   // The block's body
-  BlockBody body = 2;
+  BlockBody body = 2 [(validate.rules).message.required = true];
 }
 
 // Captures the header and all transactions in a block
 message FullBlock {
   // The block's header
-  co.topl.consensus.models.BlockHeader header = 1;
+  co.topl.consensus.models.BlockHeader header = 1 [(validate.rules).message.required = true];
   // The block's full body
-  FullBlockBody fullBody = 2;
+  FullBlockBody fullBody = 2 [(validate.rules).message.required = true];
 }
+
+option (scalapb.options) = {
+  [scalapb.validate.file] {
+    validate_at_construction: true
+  }
+  field_transformations: [
+    {
+      when: {options: {[validate.rules] {message: {required: true}}}}
+      set: {
+        [scalapb.field] {
+          required: true
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## Purpose

Add node models Block contraints validations

## Approach
header and body are now required
## Testing

```
@SerialVersionUID(0L)
final case class Block(
    header: co.topl.consensus.models.BlockHeader,
    body: co.topl.node.models.BlockBody,
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[Block] {
```


## Tickets
*
