### PR TITLE
TSDK-326: Allow reference of previous propositions

### DIFF
--- a/proto/brambl/models/box/attestation.proto
+++ b/proto/brambl/models/box/attestation.proto
@@ -1,22 +1,23 @@
 syntax = "proto3";
 
-package co.topl.brambl.models.transaction;
+package co.topl.brambl.models.box;
 
 import 'validate/validate.proto';
 import 'scalapb/scalapb.proto';
 import 'scalapb/validate.proto';
 
 import 'brambl/models/box/lock.proto';
-import 'quivr/models/proposition.proto';
+import 'brambl/models/box/challenge.proto';
 import 'quivr/models/proof.proto';
+import 'quivr/models/shared.proto';
 
 message Attestation {
     oneof value {
         Predicate predicate = 1;
         Image32 image32 = 2;
         Image64 image64 = 3;
-        // Commitment32 commitment32 = 4;
-        // Commitment64 commitment64 = 5;
+        Commitment32 commitment32 = 4;
+        Commitment64 commitment64 = 5;
     }
 
     message Predicate {
@@ -27,31 +28,35 @@ message Attestation {
     message Image32 {
         co.topl.brambl.models.box.Lock.Image32 lock = 1 [(validate.rules).message.required = true];
         // list of optional values
-        repeated quivr.models.Proposition known = 2;
+        repeated Challenge known = 2;
         // list of optional values
         repeated quivr.models.Proof responses = 3;
     }
     message Image64 {
         co.topl.brambl.models.box.Lock.Image64 lock = 1 [(validate.rules).message.required = true];
         // list of optional values
-        repeated quivr.models.Proposition known = 2;
+        repeated Challenge known = 2;
         // list of optional values
         repeated quivr.models.Proof responses = 3;
     }
-    // message Commitment32 {
-    //     co.topl.brambl.models.box.Lock.Commitment32 lock = 1 [(validate.rules).message.required = true];
-    //     // list of optional values
-    //     repeated quivr.models.Proposition known = 2;
-    //     // list of optional values
-    //     repeated quivr.models.Proof responses = 3;
-    // }
-    // message Commitment64 {
-    //     co.topl.brambl.models.box.Lock.Commitment64 lock = 1 [(validate.rules).message.required = true];
-    //     // list of optional values
-    //     repeated quivr.models.Proposition known = 2;
-    //     // list of optional values
-    //     repeated quivr.models.Proof responses = 3;
-    // }
+    message Commitment32 {
+        co.topl.brambl.models.box.Lock.Commitment32 lock = 1 [(validate.rules).message.required = true];
+        // list of claim propositions that must be proven as memebrs of the root commitment and be suitably satisfied by the given proofs
+        repeated Challenge known = 2;
+        // list of witnesses for proving membership of claimed propositions
+        repeated quivr.models.Witness witness = 3;
+        // list of optional values
+        repeated quivr.models.Proof responses = 4;
+    }
+    message Commitment64 {
+        co.topl.brambl.models.box.Lock.Commitment64 lock = 1 [(validate.rules).message.required = true];
+        // list of claim propositions that must be proven as memebrs of the root commitment and be suitably satisfied by the given proofs
+        repeated Challenge known = 2;
+        // list of witnesses for proving membership of claimed propositions
+        repeated quivr.models.Witness witness = 3;
+        // list of optional values
+        repeated quivr.models.Proof responses = 4;
+    }
     
 }
 

--- a/proto/brambl/models/box/challenge.proto
+++ b/proto/brambl/models/box/challenge.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package co.topl.brambl.models.box;
+
+
+import 'brambl/models/address.proto';
+import 'quivr/models/proposition.proto';
+
+
+// Challenge is a single field message with its options being
+// one of RevealedProposition or KnownProposition
+message Challenge {
+    oneof proposition {
+        quivr.models.Proposition revealed = 1;
+        KnownProposition known = 2;
+    }
+
+    // KnownProposition requires two parameters
+    // the transaction input address and index of the previously
+    // revealed proposition.
+    message KnownProposition {
+        TransactionInputAddress address = 1;
+        uint32 index = 2;
+    }
+}

--- a/proto/brambl/models/box/challenge.proto
+++ b/proto/brambl/models/box/challenge.proto
@@ -8,17 +8,17 @@ import 'quivr/models/proposition.proto';
 
 
 // Challenge is a single field message with its options being
-// one of RevealedProposition or KnownProposition
+// one of RevealedProposition or PreviousProposition
 message Challenge {
     oneof proposition {
         quivr.models.Proposition revealed = 1;
-        KnownProposition known = 2;
+        PreviousProposition previous = 2;
     }
 
-    // KnownProposition requires two parameters
+    // Previousroposition requires two parameters
     // the transaction input address and index of the previously
     // revealed proposition.
-    message KnownProposition {
+    message PreviousProposition {
         TransactionInputAddress address = 1;
         uint32 index = 2;
     }

--- a/proto/brambl/models/box/lock.proto
+++ b/proto/brambl/models/box/lock.proto
@@ -4,25 +4,23 @@ package co.topl.brambl.models.box;
 
 
 import 'brambl/models/identifier.proto';
-import 'quivr/models/proposition.proto';
+import 'brambl/models/box/challenge.proto';
 
 // should be able to calculate or retrieve the root of the Lock
-// - from Predicate -> Image -> Commitment
-// - from Image -> Commitment
-// - from Commitment -> _.root
+// - from Predicate -> Image -> Commitment -> Signable -> Evidence
 message Lock {
     oneof value {
         Predicate predicate = 1;
         Image32 image32 = 2;
         Image64 image64 = 3;
-        // Commitment32 commitment32 = 4;
-        // Commitment64 commitment64 = 5;
+        Commitment32 commitment32 = 4;
+        Commitment64 commitment64 = 5;
     }
 
     // Private information
     message Predicate {
-        // this should probably be a non-empty chain, but how to enforce across other languages?
-        repeated quivr.models.Proposition challenges = 1;
+        // this should probably be a non-empty chain
+        repeated Challenge challenges = 1;
         uint32 threshold = 2;
     }
     
@@ -37,16 +35,15 @@ message Lock {
         uint32 threshold = 2;
     }
 
-    // todo: jaa - should disable ot figure out how to provide the needed witness in the attestation
     // Public information
     // Predicate Commitments are used to encumber boxes
     // use a Root here so we can provide a membership proof of the conditions
-    // message Commitment32 {
-    //     co.topl.brambl.models.Identifier.AccumulatorRoot32 root = 1;
-    //     uint32 threshold = 2;
-    // }
-    // message Commitment64 {
-    //     co.topl.brambl.models.Identifier.AccumulatorRoot64 root = 1;
-    //     uint32 threshold = 2;
-    // }
+    message Commitment32 {
+        co.topl.brambl.models.Identifier.AccumulatorRoot32 root = 1;
+        uint32 threshold = 2;
+    }
+    message Commitment64 {
+        co.topl.brambl.models.Identifier.AccumulatorRoot64 root = 1;
+        uint32 threshold = 2;
+    }
 }

--- a/proto/brambl/models/transaction/spent_transaction_output.proto
+++ b/proto/brambl/models/transaction/spent_transaction_output.proto
@@ -8,11 +8,11 @@ import 'scalapb/validate.proto';
 
 import 'brambl/models/address.proto';
 import 'brambl/models/box/value.proto';
-import 'brambl/models/transaction/attestation.proto';
+import 'brambl/models/box/attestation.proto';
 
 message SpentTransactionOutput {
     co.topl.brambl.models.TransactionOutputAddress address = 1 [(validate.rules).message.required = true];
-    Attestation attestation = 2 [(validate.rules).message.required = true];
+    co.topl.brambl.models.box.Attestation attestation = 2 [(validate.rules).message.required = true];
     co.topl.brambl.models.box.Value value = 3 [(validate.rules).message.required = true];
 }
 


### PR DESCRIPTION
## Purpose
Using the `TransactionInputAddress` introduced in TSDK-325, we can modify the values placed into `Attestation`(s) or `Lock`(s) to allow for referencing of previously revealed `Propositions` within Transaction Inputs. This should allow us to save on space using previously known (or publicly known) `Proposition`(s).

## Approach
Add challenges as a wrapper for referencing previously revealed propositions

## Testing
able to run `sbt publishLocal` and `protoc` compilations

## Tickets
- TASK-326