### PR TITLE
Witness size should 64

### DIFF
--- a/proto/quivr/models/shared.proto
+++ b/proto/quivr/models/shared.proto
@@ -63,11 +63,11 @@ message KeyPair{
 }
 
 message Message {
-    bytes value = 1; // ask if we need len or max len rule
+    bytes value = 1;
 }
 
 message Witness {
-    bytes value = 1 [(validate.rules).bytes.len = 32];
+    bytes value = 1 [(validate.rules).bytes.len = 64];
 }
 
 message SignatureVerification {


### PR DESCRIPTION
```
sbt:quivr4s> test
[info] compiling 1 Scala source to /home/fernando/topl/quivr4s/target/scala-2.13/test-classes ... signature1.value.length
64
co.topl.quivr.QuivrCompositeOpsTests:
==> X co.topl.quivr.QuivrCompositeOpsTests.An and proposition must evaluate to true when both the verification of both proofs is true  0.338s scalapb.validate.FieldValidationException: Validation failed: Witness.value: length must be 32 - Got [91, 85, -114, -68, 10, -121, -30, -36, 112, 59, -69, 118, -13, 115, -9, 114, -9, -125, -54, 7, -8, 31, -15, 51, -83, 40, -100, 21, 53, 37, -112, 13, 101, 52, -76, 43, 14, 113, 38, -57, 107, 126, -91, 14, -109, 120, 105, 31, 29, 77, 40, 114, 55, -97, -90, -117, -114, 0, 21, -123, -22, 48, 21, 8]
```

## Purpose
update witness size
## Approach

## Testing

## Tickets
*
