### PR TITLE
Genus GenusFullBlockService Optional response

### DIFF
--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -103,7 +103,7 @@ message GetExistingTransactionIndexesResponse {
 }
 
 message BlockResponse {
-  node.models.FullBlock block = 1 [(validate.rules).message.required = true];
+  node.models.FullBlock block = 1;
 }
 
 message TransactionResponse {


### PR DESCRIPTION
## Purpose
Block Response should be optional to allow handling errors on grpc calls

## Testing
```scala 
final case class BlockResponse(
    block: _root_.scala.Option[co.topl.node.models.FullBlock] = _root_.scala.None,  //  optional block in response
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[BlockResponse] {
```