### PR TITLE
Naming refactor on services

### DIFF
--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -18,7 +18,7 @@ import "scalapb/scalapb.proto";
 import "scalapb/validate.proto";
 
 // Operations related to blocks
-service FullBlockService {
+service BlockService {
   // Retrieve a block with the specified `id` from the configured Genus service. This returns its result when there is a
   // block present in the genus service with the specified id and the confidence factor of the block is greater than or
   // equal to the value of the `confidenceFactor` parameter.

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -18,7 +18,7 @@ import "scalapb/scalapb.proto";
 import "scalapb/validate.proto";
 
 // Operations related to blocks
-service GenusFullBlockService {
+service FullBlockService {
   // Retrieve a block with the specified `id` from the configured Genus service. This returns its result when there is a
   // block present in the genus service with the specified id and the confidence factor of the block is greater than or
   // equal to the value of the `confidenceFactor` parameter.


### PR DESCRIPTION
 Genus Rpc contains 2 services, one of them is prefixed with  Genus, the other not,  this change removes the Genus prefix.
- GenusFullBlockService ->  FullBlockService
- TransactionService

## Purpose

## Approach

## Testing

## Tickets
