### PR TITLE
makeAddressIndexFieldOptional

### DIFF
--- a/proto/brambl/models/address.proto
+++ b/proto/brambl/models/address.proto
@@ -7,6 +7,7 @@ import 'scalapb/scalapb.proto';
 import 'scalapb/validate.proto';
 
 import 'brambl/models/identifier.proto';
+import 'google/protobuf/wrappers.proto';
 
 // An address is a location specific (network + ledger) path to a certain Identitier
 message Address {
@@ -15,7 +16,7 @@ message Address {
     // the application an Address interacts with directly
     uint32 ledger = 2;
     // optional index of another identifier possibly contained in an Event
-    uint32 index = 3;
+    google.protobuf.UInt32Value index = 3;
     // identifier of valid data with the context of (network, ledger)
     Identifier id = 4 [(validate.rules).message.required = true ];
 }


### PR DESCRIPTION
## Purpose
make Address Index Field Optional

## Testing

```scala
final case class Address(
    network: _root_.scala.Int = 0,
    ledger: _root_.scala.Int = 0,
    index: _root_.scala.Option[_root_.scala.Int] = _root_.scala.None,    // <<< Changed
    id: co.topl.brambl.models.Identifier,
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[Address]
``` 

