### PR TITLE
QueryByAddressRequest rework

### DIFF
--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -24,10 +24,11 @@ enum TxoState {
   PENDING = 2; // A transaction is pending that may spend the TXO. This state should only appear in bifrost clients.
 }
 
-// A Box and its status
+// A Txo and its status
 message Txo {
   brambl.models.transaction.UnspentTransactionOutput transactionOutput = 1 [(validate.rules).message.required = true];
   TxoState state = 2;
+  brambl.models.TransactionOutputAddress outputAddress = 3;
 }
 
 // Specify the order of data for indexes.

--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 import 'brambl/models/address.proto';
 import 'brambl/models/box/box.proto';
 import 'brambl/models/transaction/io_transaction.proto';
+import 'brambl/models/transaction/unspent_transaction_output.proto';
 import 'consensus/models/block_id.proto';
 import 'consensus/models/block_header.proto';
 import 'node/models/block.proto';
@@ -25,10 +26,8 @@ enum TxoState {
 
 // A Box and its status
 message Txo {
-  brambl.models.box.Box box = 1 [(validate.rules).message.required = true];
+  brambl.models.transaction.UnspentTransactionOutput transactionOutput = 1 [(validate.rules).message.required = true];
   TxoState state = 2;
-  brambl.models.TransactionOutputAddress outputAddress = 3;
-  brambl.models.LockAddress lockAddress = 4;
 }
 
 // Specify the order of data for indexes.

--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -28,7 +28,7 @@ enum TxoState {
 message Txo {
   brambl.models.transaction.UnspentTransactionOutput transactionOutput = 1 [(validate.rules).message.required = true];
   TxoState state = 2;
-  brambl.models.TransactionOutputAddress outputAddress = 3;
+  brambl.models.TransactionOutputAddress outputAddress = 3 [(validate.rules).message.required = true];
 }
 
 // Specify the order of data for indexes.

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -156,10 +156,7 @@ message QueryByAssetLabelRequest {
 }
 
 message TxoAddressResponse {
-  // Map Base58 encoded addresses to TxOs.
-  // string key represents a TransactionOutputAddress
-  // key_type can be any integral or string type, see: https://protobuf.dev/programming-guides/proto3/#maps
-  map<string, Txo> addressesToTxos = 1;
+  repeated Txo Txos = 1;
 }
 
 // A request to create an index of transactions based on their on-chain data

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -142,8 +142,8 @@ message CreateOnChainTransactionIndexResponse {
 
 // Used to request TxOs by their associated address
 message QueryByAddressRequest {
-  // All the addresses of interest
-  repeated brambl.models.Address addresses = 1;
+  // Address of interest
+  brambl.models.LockAddress address = 1 [(validate.rules).message.required = true];
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   ConfidenceFactor confidenceFactor = 2;
 }
@@ -157,11 +157,9 @@ message QueryByAssetLabelRequest {
 
 message TxoAddressResponse {
   // Map Base58 encoded addresses to TxOs.
+  // string key represents a TransactionOutputAddress
+  // key_type can be any integral or string type, see: https://protobuf.dev/programming-guides/proto3/#maps
   map<string, Txo> addressesToTxos = 1;
-
-  message Txos {
-    repeated genus.services.Txo txo = 1;
-  }
 }
 
 // A request to create an index of transactions based on their on-chain data

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -146,6 +146,8 @@ message QueryByAddressRequest {
   brambl.models.LockAddress address = 1 [(validate.rules).message.required = true];
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   ConfidenceFactor confidenceFactor = 2;
+  // Filter by status
+  TxoState state = 3;
 }
 
 // User to request TxOs by their asset type


### PR DESCRIPTION
## Purpose

Genus Transaction Service, QueryByAddressRequest

## Approach

- QueryByAddressRequest accepts a single LockAddress
- TxoAddressResponse returns a map<TransactionOutputAddress, Txo>
- Txo returns an UnspentTransactionOutput and TxoState

## Tickets
TODO