### PR TITLE
Create TransactionId, Remove 32/64 Distinctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed[a06dd3]
+- Remove 32/64 message types
+- Add TransactionId message
+- Add LockId message
+
 ### Changed[0b81c5]
 - Create "StakingAddress" message, used in BlockHeader and Box Value
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Protobuf specifications and definitions representing blockchain data types and c
 
 
 ## Required tools
-
 - protocol compiler: [protoc-installation](https://grpc.io/docs/protoc-installation/)
 
 
@@ -12,6 +11,7 @@ Protobuf specifications and definitions representing blockchain data types and c
     > TODO
 - Linux: 
     > sh ./run_protocol_compilers.sh
+
 
 ## Developers
 When testing changes, it helps to verify their behavior in the libraries that consume these protobuf specs.  You can publish the compiled protobuf as a "local" library and consume it in a different project.
@@ -22,6 +22,7 @@ When testing changes, it helps to verify their behavior in the libraries that co
   - i.e. `"co.topl" %% "protobuf-fs2" % "b56d2815"`
 
 ### Dart
+1. Install Dart [protoc_plugin](https://pub.dev/packages/protoc_plugin)
 1. `cd build/dart`
 1. `sh compile_protos.sh`
 1. Reference the `protobuf-specs/build/dart` directory as a pubspec file dependency
@@ -30,4 +31,3 @@ When testing changes, it helps to verify their behavior in the libraries that co
       topl_protobuf:
         path: /path/to/protobuf-specs/build/dart
     ```
-

--- a/proto/brambl/models/address.proto
+++ b/proto/brambl/models/address.proto
@@ -7,26 +7,11 @@ import 'validate/validate.proto';
 import 'brambl/models/identifier.proto';
 import 'google/protobuf/wrappers.proto';
 
-// An address is a location specific (network + ledger) path to a certain Identitier
-message Address {
-    // the chain an Address will settle to (targets the security behind an Addresses usage)
-    uint32 network = 1;
-    // the application an Address interacts with directly
-    uint32 ledger = 2;
-    // optional index of another identifier possibly contained in an Event
-    google.protobuf.UInt32Value index = 3;
-    // identifier of valid data with the context of (network, ledger)
-    Identifier id = 4 [(validate.rules).message.required = true ];
-}
-
 // Used in UTXOs
 message LockAddress {
     uint32 network = 1;
     uint32 ledger = 2;
-    oneof id {
-        Identifier.Lock32 lock32 = 3;
-        Identifier.Lock64 lock64 = 4;
-    }
+    LockId id = 3 [(validate.rules).message.required = true];
 }
 
 // Used in STXOs
@@ -35,10 +20,7 @@ message TransactionOutputAddress {
     uint32 ledger = 2;
     // index of the output (UTXO) within the transaction targeted by id.
     uint32 index = 3;
-    oneof id {
-        Identifier.IoTransaction32 ioTransaction32 = 4;
-        Identifier.IoTransaction64 ioTransaction64 = 5;
-    }
+    TransactionId id = 4 [(validate.rules).message.required = true];
 }
 
 // Used in Challenge.PreviousProposition
@@ -46,8 +28,5 @@ message TransactionInputAddress {
     uint32 network = 1;
     uint32 ledger = 2;
     uint32 index = 3;
-    oneof id {
-        Identifier.IoTransaction32 ioTransaction32 = 4;
-        Identifier.IoTransaction64 ioTransaction64 = 5;
-    }
+    TransactionId id = 4 [(validate.rules).message.required = true];
 }

--- a/proto/brambl/models/box/attestation.proto
+++ b/proto/brambl/models/box/attestation.proto
@@ -13,10 +13,8 @@ import 'quivr/models/shared.proto';
 message Attestation {
     oneof value {
         Predicate predicate = 1;
-        Image32 image32 = 2;
-        Image64 image64 = 3;
-        Commitment32 commitment32 = 4;
-        Commitment64 commitment64 = 5;
+        Image image = 2;
+        Commitment commitment = 3;
     }
 
     message Predicate {
@@ -24,31 +22,15 @@ message Attestation {
         // list of optional values (proofs used to attempt to satisfy the challenges contained in the predicate lock)
         repeated quivr.models.Proof responses = 2;
     }
-    message Image32 {
-        co.topl.brambl.models.box.Lock.Image32 lock = 1 [(validate.rules).message.required = true];
+    message Image {
+        co.topl.brambl.models.box.Lock.Image lock = 1 [(validate.rules).message.required = true];
         // list of optional values
         repeated Challenge known = 2;
         // list of optional values
         repeated quivr.models.Proof responses = 3;
     }
-    message Image64 {
-        co.topl.brambl.models.box.Lock.Image64 lock = 1 [(validate.rules).message.required = true];
-        // list of optional values
-        repeated Challenge known = 2;
-        // list of optional values
-        repeated quivr.models.Proof responses = 3;
-    }
-    message Commitment32 {
-        co.topl.brambl.models.box.Lock.Commitment32 lock = 1 [(validate.rules).message.required = true];
-        // list of claim propositions that must be proven as memebrs of the root commitment and be suitably satisfied by the given proofs
-        repeated Challenge known = 2;
-        // list of witnesses for proving membership of claimed propositions
-        repeated quivr.models.Witness witness = 3;
-        // list of optional values
-        repeated quivr.models.Proof responses = 4;
-    }
-    message Commitment64 {
-        co.topl.brambl.models.box.Lock.Commitment64 lock = 1 [(validate.rules).message.required = true];
+    message Commitment {
+        co.topl.brambl.models.box.Lock.Commitment lock = 1 [(validate.rules).message.required = true];
         // list of claim propositions that must be proven as memebrs of the root commitment and be suitably satisfied by the given proofs
         repeated Challenge known = 2;
         // list of witnesses for proving membership of claimed propositions

--- a/proto/brambl/models/box/lock.proto
+++ b/proto/brambl/models/box/lock.proto
@@ -12,10 +12,8 @@ import 'brambl/models/box/challenge.proto';
 message Lock {
     oneof value {
         Predicate predicate = 1;
-        Image32 image32 = 2;
-        Image64 image64 = 3;
-        Commitment32 commitment32 = 4;
-        Commitment64 commitment64 = 5;
+        Image image = 2;
+        Commitment commitment = 3;
     }
 
     // Private information
@@ -28,12 +26,8 @@ message Lock {
     
     // Semi-public information
     // The most commonly shared construction between parties
-    message Image32 {
-        repeated co.topl.brambl.models.Identifier.Lock32 leaves = 1;
-        uint32 threshold = 2;
-    }
-    message Image64 {
-        repeated co.topl.brambl.models.Identifier.Lock64 leaves = 1;
+    message Image {
+        repeated co.topl.brambl.models.LockId leaves = 1;
         uint32 threshold = 2;
     }
 
@@ -41,12 +35,8 @@ message Lock {
     // Public information
     // Predicate Commitments are used to encumber boxes
     // use a Root here so we can provide a membership proof of the conditions
-    message Commitment32 {
-        co.topl.brambl.models.Identifier.AccumulatorRoot32 root = 1;
-        uint32 threshold = 2;
-    }
-    message Commitment64 {
-        co.topl.brambl.models.Identifier.AccumulatorRoot64 root = 1;
+    message Commitment {
+        co.topl.brambl.models.AccumulatorRootId root = 1;
         uint32 threshold = 2;
     }
 }

--- a/proto/brambl/models/evidence.proto
+++ b/proto/brambl/models/evidence.proto
@@ -11,15 +11,5 @@ import 'quivr/models/shared.proto';
  // their own similarly unique & succinct values. Quivr can cast such external domain "evidence" into Topl evidence
  // through the use of ContainsSignable[Evidence[_]]
 message Evidence {
-    oneof value {
-        Sized32 sized32 = 1;
-        Sized64 sized64 = 2;
-    }
-
-    message Sized32 {
-        quivr.models.Digest.Digest32 digest = 1 [(validate.rules).message.required = true];
-    }
-    message Sized64 {
-        quivr.models.Digest.Digest64 digest = 1 [(validate.rules).message.required = true];
-    }
+    quivr.models.Digest digest = 1 [(validate.rules).message.required = true];
 }

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -4,40 +4,23 @@ package co.topl.brambl.models;
 
 import 'validate/validate.proto';
 
-import 'brambl/models/evidence.proto';
+// Represents the identifier of a Transction.  It is constructed from the evidence of the signable bytes of the Transaction.
+message TransactionId {
+    // The evidence of the Transaction's signable bytes
+    // length = 32
+    bytes value = 1 [(validate.rules).bytes.len = 32];
+}
 
-// Identifiers are tagged evidence of valid data with the context of (network, ledger)
-message Identifier {
-    oneof value {
-        Lock32 lock32 = 1;
-        Lock64 lock64 = 2;
-        IoTransaction32 ioTransaction32 = 3;
-        IoTransaction64 ioTransaction64 = 4;
-        AccumulatorRoot32 accumulatorRoot32 = 5;
-        AccumulatorRoot64 accumulatorRoot64 = 6;
-    }
-    // tag = box_lock_32
-    message Lock32 {
-        Evidence.Sized32 evidence = 1 [(validate.rules).message.required = true];
-    }
-    // tag = box_lock_64
-    message Lock64 {
-        Evidence.Sized64 evidence = 1 [(validate.rules).message.required = true];
-    }
-    // tag = iotx_32
-    message IoTransaction32 {
-        Evidence.Sized32 evidence = 1 [(validate.rules).message.required = true];
-    }
-    // tag = iotx_64
-    message IoTransaction64 {
-        Evidence.Sized64 evidence = 1 [(validate.rules).message.required = true];
-    }
-    // tag = acc_root_32
-    message AccumulatorRoot32 {
-        Evidence.Sized32 evidence = 1 [(validate.rules).message.required = true];
-    }
-    // tag = acc_root_64
-    message AccumulatorRoot64 {
-        Evidence.Sized64 evidence = 1 [(validate.rules).message.required = true];
-    }
+// Represents the identifier of a Lock.  It is constructed from the evidence of the signable bytes of the Lock.
+message LockId {
+    // The evidence of the Lock's signable bytes
+    // length = 32
+    bytes value = 1 [(validate.rules).bytes.len = 32];
+}
+
+// Represents the identifier of an Accumulator Root.  It is constructed from the evidence of the signable bytes of the Lock.
+message AccumulatorRootId {
+    // The evidence of the Accumulator Root's signable bytes
+    // length = 32
+    bytes value = 1 [(validate.rules).bytes.len = 32];
 }

--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -71,7 +71,7 @@ message AssetLabel {
 
   message V1Label {
     uint32 version = 1;
-    brambl.models.Address mintingAddress = 2 [(validate.rules).message.required = true];
+    brambl.models.LockAddress mintingAddress = 2 [(validate.rules).message.required = true];
   }
 
   message Tam2Label {

--- a/proto/genus/genus_rpc.proto
+++ b/proto/genus/genus_rpc.proto
@@ -129,7 +129,7 @@ message GetBlockByDepthRequest {
 
 // Used to request a transaction by specifying its ID.
 message GetTransactionByIdRequest {
-  brambl.models.Identifier.IoTransaction32 transactionId = 1 [(validate.rules).message.required = true];
+  brambl.models.TransactionId transactionId = 1 [(validate.rules).message.required = true];
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   ConfidenceFactor confidenceFactor = 2;
 }
@@ -143,7 +143,7 @@ message CreateOnChainTransactionIndexResponse {
 // Used to request TxOs by their associated address
 message QueryByAddressRequest {
   // All the addresses of interest
-  repeated brambl.models.Address addresses = 1;
+  repeated brambl.models.LockAddress addresses = 1;
   // The default value for confidenceFactor is 0.9999999 (7 nines)
   ConfidenceFactor confidenceFactor = 2;
 }

--- a/proto/node/models/block.proto
+++ b/proto/node/models/block.proto
@@ -11,7 +11,7 @@ import "validate/validate.proto";
 // Captures the ordering of transaction IDs within a block
 message BlockBody {
   // A list of Transaction IDs included in this block
-  repeated co.topl.brambl.models.Identifier.IoTransaction32 transactionIds = 1;
+  repeated co.topl.brambl.models.TransactionId transactionIds = 1;
 }
 
 // Captures the ordering of transactions (not just IDs) within a block

--- a/proto/node/services/bifrost_rpc.proto
+++ b/proto/node/services/bifrost_rpc.proto
@@ -50,7 +50,7 @@ message CurrentMempoolReq {}
 // Response type for CurrentMempool
 message CurrentMempoolRes {
   // A list of Transaction IDs that are currently in the node's mempool
-  repeated co.topl.brambl.models.Identifier.IoTransaction32 transactionIds = 1;
+  repeated co.topl.brambl.models.TransactionId transactionIds = 1;
 }
 
 // Request type for FetchBlockHeader
@@ -81,7 +81,7 @@ message FetchBlockBodyRes {
 
 // Request type for FetchTransaction
 message FetchTransactionReq {
-  co.topl.brambl.models.Identifier.IoTransaction32 transactionId = 1 [(validate.rules).message.required = true];
+  co.topl.brambl.models.TransactionId transactionId = 1 [(validate.rules).message.required = true];
 }
 
 // Response type for FetchTransaction

--- a/proto/quivr/models/shared.proto
+++ b/proto/quivr/models/shared.proto
@@ -18,10 +18,7 @@ message SmallData {
 
 // Event root
 message Root {
-    oneof value {
-        bytes root32 = 1 [(validate.rules).bytes.len = 32];
-        bytes root64 = 2 [(validate.rules).bytes.len = 64];
-    }
+    bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Preimage (input) for a digest operation
@@ -32,20 +29,8 @@ message Preimage {
 
 // Information output to Hash
 message Digest {
-    oneof value {
-        Digest32 digest32 = 1;
-        Digest64 digest64 = 2;
-    }
-
-    message Digest32 {
-        // strict length = 32
-        bytes value = 1 [(validate.rules).bytes.len = 32];
-    }
-
-    message Digest64 {
-        // strict length = 64
-        bytes value = 1 [(validate.rules).bytes.len = 64];
-    }
+    // strict length = 32
+    bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Encapsulates digest and preimage used to verify that preimage results in digest


### PR DESCRIPTION
## Purpose
- Interacting with Transaction IDs is cumbersome due to the nested types
- Separate types for 32/64-length values adds overhead to the code
## Approach
- Create TransactionId, LockId, and AccumulatorRootId.  Remove Identifier super-type.
- Remove Address super-type
- Remove 32/64 distinctions for types, collapsed into a single type at 32-bytes
## Testing
- Implemented in Quivr4s, BramblSc, and Bifrost
## Tickets
- #BN-963
