### PR TITLE
Add transactionId and headerId Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed[36a496]
+- Add transactionId field to IoTransaction message
+- Add headerId field to BlockHeader message
+
 ### Changed[a06dd3]
 - Remove 32/64 message types
 - Add TransactionId message

--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -5,11 +5,15 @@ package co.topl.brambl.models.transaction;
 import 'validate/validate.proto';
 
 import 'brambl/models/datum.proto';
+import 'brambl/models/identifier.proto';
 import 'brambl/models/transaction/spent_transaction_output.proto';
 import 'brambl/models/transaction/unspent_transaction_output.proto';
 
 // defines a transaction
 message IoTransaction {
+    // The ID of _this_ transaction.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+    // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
+    co.topl.brambl.models.TransactionId transactionId = 4;
     // 0-to-many list of inputs
     repeated SpentTransactionOutput inputs = 1;
     // 0-to-many list of outputs

--- a/proto/consensus/models/block_header.proto
+++ b/proto/consensus/models/block_header.proto
@@ -11,8 +11,10 @@ import "validate/validate.proto";
 
 // Captures a block producer's consensus-commitment to a new block
 message BlockHeader {
+  // The ID of _this_ block header.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+  // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
+  BlockId headerId = 12;
   // The parent block's ID.  Each header builds from a single parent.
-  // length = 32
   BlockId parentHeaderId = 1 [(validate.rules).message.required = true];
   // The slot of the parent block
   uint64 parentSlot = 2;


### PR DESCRIPTION
## Purpose
- Transactions and Block Headers are self-identifying, but sometimes it is convenient to include their IDs in the underlying models to avoid re-computation
## Approach
- Add `transactionId` to IoTransaction
- Add `headerId` to BlockHeader
## Testing
- Implemented in BramblSc and Bifrost
## Tickets
- #BN-995