### PR TITLE
Bn 696

### DIFF
--- a/proto/node/models/node_config.proto
+++ b/proto/node/models/node_config.proto
@@ -2,14 +2,14 @@ syntax = "proto3";
 
 package co.topl.proto.node;
 
-// Contains the configurations of the node over time
-message NodeConfigMap {
-  // Map slot numbers to node configurations. The key in the map is the first slot number that the configuration is effective.
-  map <uint64, NodeConfig> slotConfigMap = 1;
-}
+import "validate/validate.proto";
 
-// The configuration of the node the client is working with. There should be more fields in this.
+// Contains the configurations of the node over time
 message NodeConfig {
-  // the configured duration of
-  uint32 slotDurationMillis = 1;
+  // Slot number
+  uint64 slotNumber = 1;
+  // Configured slot duration
+  uint32 slotDurationMillis = 2;
+  // Node computed epochLength
+  uint64 epochLength = 3;
 }

--- a/proto/node/models/node_config.proto
+++ b/proto/node/models/node_config.proto
@@ -9,7 +9,7 @@ message NodeConfig {
   // Slot number
   uint64 slotNumber = 1;
   // Configured slot duration
-  uint32 slotDurationMillis = 2;
+  uint64 slotDurationMillis = 2;
   // Node computed epochLength
   uint64 epochLength = 3;
 }

--- a/proto/node/models/node_config.proto
+++ b/proto/node/models/node_config.proto
@@ -7,7 +7,7 @@ import "validate/validate.proto";
 // Contains the configurations of the node over time
 message NodeConfig {
   // Slot number
-  uint64 slotNumber = 1;
+  uint64 slot = 1;
   // Configured slot duration
   uint64 slotDurationMillis = 2;
   // Node computed epochLength

--- a/proto/node/services/bifrost_rpc.proto
+++ b/proto/node/services/bifrost_rpc.proto
@@ -5,6 +5,7 @@ package co.topl.node.services;
 import 'consensus/models/block_id.proto';
 import 'consensus/models/block_header.proto';
 import 'node/models/block.proto';
+import 'node/models/node_config.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/transaction/io_transaction.proto';
 
@@ -36,6 +37,9 @@ service NodeRpc {
 
   // retrieve a stream of changes to the canonical head of the chain.
   rpc SynchronizationTraversal (SynchronizationTraversalReq) returns (stream SynchronizationTraversalRes);
+
+  // Returns the node's configuration information
+  rpc GetNodeConfig (GetNodeConfigReq) returns (stream GetNodeConfigRes);
 }
 
 // Request type for BroadcastTransaction
@@ -142,4 +146,12 @@ message SynchronizationTraversalRes {
     // Block ID unapplied
     co.topl.consensus.models.BlockId unapplied = 2;
   }
+}
+
+// Request type for GetNodeConfigReq
+message GetNodeConfigReq {}
+
+// Response type for GetNodeConfigReq
+message GetNodeConfigRes {
+  co.topl.proto.node.NodeConfig config = 1;
 }

--- a/proto/node/services/bifrost_rpc.proto
+++ b/proto/node/services/bifrost_rpc.proto
@@ -38,8 +38,8 @@ service NodeRpc {
   // retrieve a stream of changes to the canonical head of the chain.
   rpc SynchronizationTraversal (SynchronizationTraversalReq) returns (stream SynchronizationTraversalRes);
 
-  // Returns the node's configuration information
-  rpc GetNodeConfig (GetNodeConfigReq) returns (stream GetNodeConfigRes);
+  // retrieve a stream of node's protocol configuration
+  rpc FetchNodeConfig (FetchNodeConfigReq) returns (stream FetchNodeConfigRes);
 }
 
 // Request type for BroadcastTransaction
@@ -148,10 +148,10 @@ message SynchronizationTraversalRes {
   }
 }
 
-// Request type for GetNodeConfigReq
-message GetNodeConfigReq {}
+// Request type for FetchNodeConfigReq
+message FetchNodeConfigReq {}
 
-// Response type for GetNodeConfigReq
-message GetNodeConfigRes {
+// Response type for FetchNodeConfigReq
+message FetchNodeConfigRes {
   co.topl.proto.node.NodeConfig config = 1 [(validate.rules).message.required = true];
 }

--- a/proto/node/services/bifrost_rpc.proto
+++ b/proto/node/services/bifrost_rpc.proto
@@ -153,5 +153,5 @@ message GetNodeConfigReq {}
 
 // Response type for GetNodeConfigReq
 message GetNodeConfigRes {
-  co.topl.proto.node.NodeConfig config = 1;
+  co.topl.proto.node.NodeConfig config = 1 [(validate.rules).message.required = true];
 }


### PR DESCRIPTION
## Purpose

Add a new RPC to the NodeRpc service named getNodeConfig that returns the node's configuration information, including the slot duration.

The message type returned from getNodeConfig should be co.topl.proto.models.node.NodeConfig.
## Approach

## Testing
protobuf-specs compile

## Tickets
https://topl.atlassian.net/browse/BN-696
