### PR TITLE
BN-1047 blockHeader optional size

### DIFF
--- a/proto/consensus/models/block_header.proto
+++ b/proto/consensus/models/block_header.proto
@@ -6,6 +6,7 @@ import 'consensus/models/block_id.proto';
 import 'consensus/models/eligibility_certificate.proto';
 import 'consensus/models/operational_certificate.proto';
 import 'consensus/models/staking_address.proto';
+import 'google/protobuf/wrappers.proto';
 
 import "validate/validate.proto";
 
@@ -39,4 +40,7 @@ message BlockHeader {
   bytes metadata = 10 [(validate.rules).bytes.max_len = 32];
   // The operator's staking address
   StakingAddress address = 11 [(validate.rules).message.required = true];
+  // The size of _this_ block header. This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+  // Some gRpc implementations could eventually fulfill this value, which reference the immutable bytes size.
+  google.protobuf.UInt64Value size = 13;
 }


### PR DESCRIPTION
## Purpose
- Return  Blockheader size on Genus/Node rpc, size is on orientdb
## Approach
- optional size field on blockheader

## Testing

```
final case class BlockHeader(
    headerId: _root_.scala.Option[co.topl.consensus.models.BlockId] = _root_.scala.None,
    parentHeaderId: co.topl.consensus.models.BlockId,
    parentSlot: _root_.scala.Long = 0L,
    txRoot: _root_.com.google.protobuf.ByteString = _root_.com.google.protobuf.ByteString.EMPTY,
    bloomFilter: _root_.com.google.protobuf.ByteString = _root_.com.google.protobuf.ByteString.EMPTY,
    timestamp: _root_.scala.Long = 0L,
    height: _root_.scala.Long = 0L,
    slot: _root_.scala.Long = 0L,
    eligibilityCertificate: co.topl.consensus.models.EligibilityCertificate,
    operationalCertificate: co.topl.consensus.models.OperationalCertificate,
    metadata: _root_.com.google.protobuf.ByteString = _root_.com.google.protobuf.ByteString.EMPTY,
    address: co.topl.consensus.models.StakingAddress,
    size: _root_.scala.Option[_root_.scala.Long] = _root_.scala.None,   ##############################3
    unknownFields: _root_.scalapb.UnknownFieldSet = _root_.scalapb.UnknownFieldSet.empty
    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[BlockHeader] {
```

## Tickets
