### PR TITLE
BN-1047-V2-return-blockheader-size

### DIFF
--- a/proto/node/models/block.proto
+++ b/proto/node/models/block.proto
@@ -7,6 +7,7 @@ import 'brambl/models/transaction/io_transaction.proto';
 import 'brambl/models/identifier.proto';
 
 import "validate/validate.proto";
+import 'google/protobuf/wrappers.proto';
 
 // Captures the ordering of transaction IDs within a block
 message BlockBody {
@@ -34,4 +35,7 @@ message FullBlock {
   co.topl.consensus.models.BlockHeader header = 1 [(validate.rules).message.required = true];
   // The block's full body
   FullBlockBody fullBody = 2 [(validate.rules).message.required = true];
+  // The size of _this_ block header. This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+  // Some gRpc implementations could eventually fulfill this value, which reference the immutable bytes size.
+  google.protobuf.UInt64Value headerSize = 3;
 }

--- a/proto/node/services/bifrost_rpc.proto
+++ b/proto/node/services/bifrost_rpc.proto
@@ -10,6 +10,7 @@ import 'brambl/models/identifier.proto';
 import 'brambl/models/transaction/io_transaction.proto';
 
 import "validate/validate.proto";
+import 'google/protobuf/wrappers.proto';
 
 service NodeRpc {
   // Submit a proven Transaction to the node
@@ -82,6 +83,9 @@ message FetchBlockHeaderRes {
   // The Block Header associated with the requested ID.  None/null if not found.
   // optional
   co.topl.consensus.models.BlockHeader header = 1;
+  // The size of _this_ block header. This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+  // Some gRpc implementations could eventually fulfill this value, which reference the immutable bytes size.
+  google.protobuf.UInt64Value headerSize = 2;
 }
 
 // Request type for FetchBlockBody


### PR DESCRIPTION
## Purpose
- Alternative Pr with a different Implementation:  see https://github.com/Topl/protobuf-specs/pull/66
- the previous Pr defines the size inside the blockheader, this one returns the size on each Rpc response
- Return  Blockheader size on Genus/Node rpcs

