### PR TITLE
TSDK-498 Maven deploy tooling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Pull Requests
+  
+  $CHANGES

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy (release only)
         run: sbt ci-release
         working-directory: ./build/scala

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
 name: deploy
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    tags: ["*"]
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: deploy
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Protoc Build
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.release
+        name: Checkout current branch
+        uses: actions/checkout@v2
+      - if: github.event.release
+        name: Setup Protoc
+        run: sudo apt install -y protobuf-compiler
+      - if: github.event.release
+        name: Compile and Test
+        run: sh run_protocol_compilers.sh
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.release
+        name: Checkout code
+        uses: actions/checkout@v2
+      - if: github.event.release
+        name: Deploy (release only)
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,27 +6,19 @@ on:
 jobs:
   build:
     name: Protoc Build
-    runs-on: ubuntu-latest
-    steps:
-      - if: github.event.release
-        name: Checkout current branch
-        uses: actions/checkout@v2
-      - if: github.event.release
-        name: Setup Protoc
-        run: sudo apt install -y protobuf-compiler
-      - if: github.event.release
-        name: Compile and Test
-        run: sh run_protocol_compilers.sh
+    uses: ./.github/workflows/_protoc_build.yml
+    with:
+      preserve-cache-between-runs: true
   publish:
-    name: Publish
+    name: Build and Publish
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - if: github.event.release
-        name: Checkout code
+      - name: Checkout code
         uses: actions/checkout@v2
-      - if: github.event.release
-        name: Deploy (release only)
+      - name: Deploy (release only)
         run: sbt ci-release
+        working-directory: ./build/scala
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,11 @@
 name: deploy
-#on:
-#  release:
-#    types: [published]
-
 on:
-  push:
-    branches: [ TSDK-498-maven-deploy ]
+  release:
+    types: [published]
 
 jobs:
   build:
-    name: Protoc Build
+    name: Protoc Test Build and Compile
     uses: ./.github/workflows/_protoc_build.yml
   publish:
     name: Build and Publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,11 @@
 name: deploy
+#on:
+#  release:
+#    types: [published]
+
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ TSDK-498-maven-deploy ]
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     name: Protoc Build
     uses: ./.github/workflows/_protoc_build.yml
-    with:
-      preserve-cache-between-runs: true
   publish:
     name: Build and Publish
     needs: build

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ TSDK-498-maven-deploy ]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches: [ TSDK-498-maven-deploy ]
+    branches: [ main ]
 
 jobs:
   update_release_draft:

--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -3,8 +3,9 @@ val scala213 = "2.13.10"
 inThisBuild(
   List(
     organization := "co.topl",
-    scalaVersion := scala213,
-    version := "2.0.0.alpha-1"
+    scalaVersion := scala213
+    // sbt-ci-release says not to set version as it is handled by sbt-dynver
+    //  version := "2.0.0.alpha-1"
     // TODO: This version will need to follow a different version scheme once we're ready to publish to maven.
     // For now, it will default to the latest git commit hash.
     // version := dynverGitDescribeOutput.value.mkVersion(_.ref.value, "local")

--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -4,11 +4,6 @@ inThisBuild(
   List(
     organization := "co.topl",
     scalaVersion := scala213
-    // sbt-ci-release says not to set version as it is handled by sbt-dynver
-    //  version := "2.0.0.alpha-1"
-    // TODO: This version will need to follow a different version scheme once we're ready to publish to maven.
-    // For now, it will default to the latest git commit hash.
-    // version := dynverGitDescribeOutput.value.mkVersion(_.ref.value, "local")
   )
 )
 

--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -4,9 +4,10 @@ inThisBuild(
   List(
     organization := "co.topl",
     scalaVersion := scala213,
+    version := "2.0.0.alpha-1"
     // TODO: This version will need to follow a different version scheme once we're ready to publish to maven.
     // For now, it will default to the latest git commit hash.
-    version := dynverGitDescribeOutput.value.mkVersion(_.ref.value, "local")
+    // version := dynverGitDescribeOutput.value.mkVersion(_.ref.value, "local")
   )
 )
 
@@ -17,6 +18,8 @@ lazy val commonSettings = Seq(
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/Topl/protobuf-specs")),
   licenses := Seq("MPL2.0" -> url("https://www.mozilla.org/en-US/MPL/2.0/")),
+  sonatypeCredentialHost := "s01.oss.sonatype.org",
+  sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   Test / publishArtifact := false,
   pomIncludeRepository := { _ => false },
   pomExtra :=

--- a/build/scala/project/plugins.sbt
+++ b/build/scala/project/plugins.sbt
@@ -4,7 +4,8 @@ Seq(
   "com.github.sbt"          % "sbt-ci-release"            % "1.5.11",
   "net.bzzt"                % "sbt-reproducible-builds"   % "0.30",
   "org.typelevel"           % "sbt-fs2-grpc"              % "2.4.12",
-  "com.thesamet"            % "sbt-protoc"                % "1.0.3"
+  "com.thesamet"            % "sbt-protoc"                % "1.0.3",
+  "com.github.sbt"          % "sbt-ci-release"            % "1.5.12"
 ).map(addSbtPlugin)
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
## Purpose

Tooling for publishing Protobuf specs to Maven

## Approach

- Added Release drafter workflow
- Added publish workflow (added the necessary secrets to the repo)
- note: version is removed from build.sbt since sbt-ci-release says not to set version as it is handled by sbt-dynver

## Testing

- Ensured publish workflow is successful > Github Actions ran successfully and artifact snapshot exists in sonatype repo
- Ensured artifact snapshot is accessible from coursier > Ran `cs fetch co.topl:protobuf-fs2_2.13:0.0.0+1-955197d7-SNAPSHOT -r https://s01.oss.sonatype.org/content/repositories/snapshots` > fetch from sonatype repo was successful 
- Ensured artifact snapshot  is usable from another project >  In the quivr4s repo, updated the protobuf-specs dependency to refer to the sonatype snapshot > the snapshot artifact is being used and all tests pass
![image](https://github.com/Topl/protobuf-specs/assets/17934976/0382a41e-93d3-47ab-ac1d-a269f1336be7)
- Ensured `sbt publishLocal` still works (sanity)


Could not yet test (will do after PR is merged):
- Release drafter workflow (file needs to be on the main branch)
- Proper version or access from maven central since there have been no releases 

## Tickets
* TSDK-498