### PR TITLE
TSDK-498 Debugging deploying to Maven

### DIFF
--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/Topl/protobuf-specs")),
   licenses := Seq("MPL2.0" -> url("https://www.mozilla.org/en-US/MPL/2.0/")),
-  sonatypeCredentialHost := "s01.oss.sonatype.org",
+  ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
   sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   Test / publishArtifact := false,
   pomIncludeRepository := { _ => false },

--- a/build/scala/project/plugins.sbt
+++ b/build/scala/project/plugins.sbt
@@ -1,7 +1,6 @@
 Seq(
   "com.github.sbt"          % "sbt-release"               % "1.1.0",
   "com.eed3si9n"            % "sbt-buildinfo"             % "0.11.0",
-  "com.github.sbt"          % "sbt-ci-release"            % "1.5.11",
   "net.bzzt"                % "sbt-reproducible-builds"   % "0.30",
   "org.typelevel"           % "sbt-fs2-grpc"              % "2.4.12",
   "com.thesamet"            % "sbt-protoc"                % "1.0.3",


### PR DESCRIPTION
## Purpose

In a previous PR, tooling to deploy to maven was added. Snapshots are correctly being published to the Sonatype repo and pushing a tag on main successfully triggers the publish workflow (and tags the artifact correctly). However, the publish workflow is failing for non Snapshots.

Specifically, the workflow is attempting to publish the artifact to the wrong Sonatype repository.

In the logs, we can see that it is attempting to publish to https://oss.sonatype.org/service/local and fails with 401 Unauthorized

![image](https://github.com/Topl/protobuf-specs/assets/17934976/9b5cc15f-1fa9-47f3-8da2-280eb1103363)

It fails since our Sonatype credentials are meant for https://*****s01*****.oss.sonatype.org/service/local 

Note that we only have access to the Nexus repository for s01.oss.sonatype.org not oss.sonatype.org

![image](https://github.com/Topl/protobuf-specs/assets/17934976/caea7f06-10bc-4102-96a1-da1cdd57d96a)

![image](https://github.com/Topl/protobuf-specs/assets/17934976/776a28f4-6644-49c2-90f9-c1bf59754302)

Per documentation in https://github.com/sbt/sbt-ci-release, the default behavior is to use the oss.sonatype.org server location, unless otherwise specified.

```
ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
```

"ThisBuild / " was missing from our implementation

![image](https://github.com/Topl/protobuf-specs/assets/17934976/bd29aff1-278a-4c1d-a3bd-197cccaea4ad)

Per https://github.com/sbt/sbt-ci-release/pull/258 , Without "ThisBuild / ", publishing with this setting would break in multi-project builds.

It is unclear if this change will fix the aforementioned issue since this was not a problem for SNAPSHOT publishing. They were successfully published to the correct server. 
![image](https://github.com/Topl/protobuf-specs/assets/17934976/fb639000-0c80-4423-a695-b717c22395f0)

## Approach

- Prepended "ThisBuild / " to sonatypeCredentialHost in build.sbt (as mentioned above)
- Removed duplicate plugin; "com.github.sbt" % "sbt-ci-release" was included twice

## Testing

Ran "sbt publishLocal" for sanity

## Tickets
* Part of TSDK-498 

