### PR TITLE
Staking/Registration Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed[Release - v2.0.0-alpha2 | todo replace: next commit hash]
+- Remove "Registration" Box Value
+- Create co.topl.consensus.models.StakingRegistration message
+- Create co.topl.consensus.models.ActiveStaker message
+- Remove "stakingAddress" field from Topl Box Value
+- Embed "StakingRegistration" in Topl Box Value
+
 ### Added[Release - v2.0.0-alpha2 | todo replace: next commit hash]
 - Retrieve Epoch Data Stats, Node rpc `fetchEpochData`
 

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -6,7 +6,7 @@ import 'validate/validate.proto';
 
 import 'quivr/models/shared.proto';
 import 'consensus/models/operational_certificate.proto';
-import 'consensus/models/staking_address.proto';
+import 'consensus/models/staking.proto';
 
 // The value contained in a box
 message Value {
@@ -23,12 +23,8 @@ message Value {
     message TOPL {
         quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
         // Optional.  If provided, the registration will take effect at the start of 2 epochs from now. If not provided, this token will not be used for staking purposes.
-        Registration registration = 3;
-        // A proof-of-stake registration
-        message Registration {
-            co.topl.consensus.models.SignatureKesProduct signature = 1 [(validate.rules).message.required = true];
-            co.topl.consensus.models.StakingAddress stakingAddress = 2 [(validate.rules).message.required = true];
-        }
+        co.topl.consensus.models.StakingRegistration registration = 3;
+        
     }
     // A user-defined token
     message Asset {

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -14,7 +14,6 @@ message Value {
         LVL lvl = 1;
         TOPL topl = 2;
         Asset asset = 3;
-        Registration registration = 4;
     }
     // A payment token
     message LVL {
@@ -23,18 +22,18 @@ message Value {
     // A staking token
     message TOPL {
         quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
-        // Optional.  If not provided, this token will not be used for staking purposes.
-        co.topl.consensus.models.StakingAddress stakingAddress = 2;
+        // Optional.  If provided, the registration will take effect at the start of 2 epochs from now. If not provided, this token will not be used for staking purposes.
+        Registration registration = 3;
+        // A proof-of-stake registration
+        message Registration {
+            co.topl.consensus.models.SignatureKesProduct signature = 1 [(validate.rules).message.required = true];
+            co.topl.consensus.models.StakingAddress stakingAddress = 2 [(validate.rules).message.required = true];
+        }
     }
     // A user-defined token
     message Asset {
         string label = 1;
         quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
         quivr.models.SmallData metadata = 3 [(validate.rules).message.required = true];
-    }
-    // A proof-of-stake registration token
-    message Registration {
-        co.topl.consensus.models.SignatureKesProduct registration = 1 [(validate.rules).message.required = true];
-        co.topl.consensus.models.StakingAddress stakingAddress = 2 [(validate.rules).message.required = true];
     }
 }

--- a/proto/consensus/models/block_header.proto
+++ b/proto/consensus/models/block_header.proto
@@ -5,7 +5,7 @@ package co.topl.consensus.models;
 import 'consensus/models/block_id.proto';
 import 'consensus/models/eligibility_certificate.proto';
 import 'consensus/models/operational_certificate.proto';
-import 'consensus/models/staking_address.proto';
+import 'consensus/models/staking.proto';
 
 import "validate/validate.proto";
 

--- a/proto/consensus/models/staking.proto
+++ b/proto/consensus/models/staking.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package co.topl.consensus.models;
+
+import 'quivr/models/shared.proto';
+import 'consensus/models/operational_certificate.proto';
+
+import 'validate/validate.proto';
+
+// A reference to a unique staker
+message StakingAddress {
+    // The address bytes of the staker, usually an ed25519 VK
+    bytes value = 1 [(validate.rules).bytes.len = 32];
+}
+
+// A proof-of-stake registration
+message StakingRegistration {
+    // the staker's address
+    co.topl.consensus.models.StakingAddress address = 1 [(validate.rules).message.required = true];
+    // the staker's commitment to a VRF VK and StakingAddress, signed using KES SK at timestep=0
+    co.topl.consensus.models.SignatureKesProduct signature = 2 [(validate.rules).message.required = true];
+}
+
+// An active, registered participate in the consensus protocol, for a particular epoch.
+message ActiveStaker {
+    // the staker's registration
+    StakingRegistration registration = 1 [(validate.rules).message.required = true];
+    // the quantity of staked tokens for the epoch
+    quivr.models.Int128 quantity = 3 [(validate.rules).message.required = true];
+}

--- a/proto/consensus/models/staking_address.proto
+++ b/proto/consensus/models/staking_address.proto
@@ -1,9 +1,0 @@
-syntax = "proto3";
-
-package co.topl.consensus.models;
-
-import 'validate/validate.proto';
-
-message StakingAddress {
-    bytes value = 1 [(validate.rules).bytes.len = 32];
-}


### PR DESCRIPTION
## Purpose
- Previously, Staking Registration and Staking Tokens were decoupled which could lead to cases where users may register with 0 stake, or users may assign stake to a registration that does not exist
- This PR combines Registration with the Staking Token to prevent such cases
## Approach
- Rename staking_address.proto to staking.proto, create StakingRegistration and ActiveStaker messages
- Remove Registration Box Value
- Replace "stakingAddress" field in Topl Box value with a StakingRegistration
## Testing
- Implemented in BramblSc and Bifrost
## Tickets
- #BN-770