### PR TITLE
TSDK-507 Release drafts should not contain changes from previous pre-release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+include-pre-releases: true
 template: |
   ## Pull Requests
   

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+prerelease: true
 include-pre-releases: true
 template: |
   ## Pull Requests


### PR DESCRIPTION
## Purpose

The release draft that was drafted for alpha2 also contained all PRs that was in alpha1. This issue is currently not visible in this repo because there is no release draft in progress (there will be after this merge). 

## Approach

- Added configuration flag to consider pre-releases as a "full" release when drafting notes
- Also added configuration flag to mark as pre-release by default to streamline process 

## Testing

- Tested in my own personal repo that this change fixes the issue
- The test for this repo will be apparent after we merge

## Tickets
* TSDK-507