### PR TITLE
BN-1138/113434 group and series asset token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [v2.0.0-alpha3] - TODO
+
+### Added
+ 
 - TAM V2 Group Access token models
 
 ## [Released] 
 
 ## [v2.0.0-alpha2] - Fri Jun 30 14:41:29 UTC 2023
+
+### Changed
+
 - Remove "Registration" Box Value
 - Create co.topl.consensus.models.StakingRegistration message
 - Create co.topl.consensus.models.ActiveStaker message
@@ -21,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retrieve Epoch Data Stats, Node rpc `fetchEpochData`
 
 ## [v2.0.0-alpha1] - Mon Jun 12 13:53:06 UTC 2023
+
+### Added
+ 
 - all the below changes were included on Sonatype releases repository
 
 ### Added[ae3f01d]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed[Release - v2.0.0-alpha2 | todo replace: next commit hash]
+## [v2.0.0-alpha3] - TODO
+- TAM V2 Group Access token models
+
+## [Released] 
+
+## [v2.0.0-alpha2] - Fri Jun 30 14:41:29 UTC 2023
 - Remove "Registration" Box Value
 - Create co.topl.consensus.models.StakingRegistration message
 - Create co.topl.consensus.models.ActiveStaker message
 - Remove "stakingAddress" field from Topl Box Value
 - Embed "StakingRegistration" in Topl Box Value
-
-### Added[Release - v2.0.0-alpha2 | todo replace: next commit hash]
 - Retrieve Epoch Data Stats, Node rpc `fetchEpochData`
+
+## [v2.0.0-alpha1] - Mon Jun 12 13:53:06 UTC 2023
+- all the below changes were included on Sonatype releases repository
 
 ### Added[ae3f01d]
 - Retrieve Block Stats, Genus rpc `getBlockStats`

--- a/proto/brambl/models/box/asset.proto
+++ b/proto/brambl/models/box/asset.proto
@@ -2,25 +2,6 @@ syntax = "proto3";
 
 package co.topl.brambl.models.box;
 
-message SeriesTokenSupply {
-  oneof value {
-    SeriesTokenSupplyEnum enum = 1;
-    Capped capped = 2;
-  }
-}
-
-enum SeriesTokenSupplyEnum {
-  // we can mint as many tokens as we want of a given asset
-  UNLIMITED = 0;
-  // the same as capped but the network enforces that all tokens are minted in only one transaction.
-  FIXED = 1;
-}
-
-message Capped {
-  // can only mint up to a certain amount of tokens of a given series.
-  uint64 supply = 1 ;
-}
-
 // Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
 message FixedSeries {
   // SHA256 series policy

--- a/proto/brambl/models/box/asset.proto
+++ b/proto/brambl/models/box/asset.proto
@@ -1,9 +1,24 @@
 syntax = "proto3";
 
 package co.topl.brambl.models.box;
+import 'validate/validate.proto';
 
-// Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
-message FixedSeries {
-  // SHA256 series policy
-  string value = 1;
+enum FungibilityType {
+  // `group-and-series` means that both the series and the group are considered for fungibility.
+  GROUP_AND_SERIES = 0;
+  // `series` means that only the series is considered for fungibility.
+  SERIES = 1;
+  // `group` means that only the group is considered for fungibility
+  GROUP = 2;
+}
+
+enum QuantityDescriptorType{
+  // `standard` means that the token has the standard behavior. If it is fungible one can fraction it in smaller tokens or merge two smaller tokens to make a bigger one.
+  STANDARD = 0;
+  // `accumulator` means that the token can only be merged with other fungible tokens. Once two tokens are merged they can never be separated and will always share the same UTXO.
+  ACCUMULATOR = 1;
+  // `fractionable` means that the token can only be split but not merged with other fungible tokens. Once the token was split it can never be put together again.
+  FRACTIONABLE = 2;
+  // `immutable` means that a token can neither be accumulated nor split, it always keeps the same quantity.
+  IMMUTABLE = 3;
 }

--- a/proto/brambl/models/box/asset.proto
+++ b/proto/brambl/models/box/asset.proto
@@ -4,21 +4,22 @@ package co.topl.brambl.models.box;
 
 message SeriesTokenSupply {
   oneof value {
-    // we can mint as many tokens as we want of a given asset
-    Unlimited unlimited = 1;
-    // can only mint up to a certain amount of tokens of a given series.
+    SeriesTokenSupplyEnum enum = 1;
     Capped capped = 2;
-    // the same as capped but the network enforces that all tokens are minted in only one transaction.
-    Fixed fixed = 3;
   }
 }
 
+enum SeriesTokenSupplyEnum {
+  // we can mint as many tokens as we want of a given asset
+  UNLIMITED = 0;
+  // the same as capped but the network enforces that all tokens are minted in only one transaction.
+  FIXED = 1;
+}
+
 message Capped {
+  // can only mint up to a certain amount of tokens of a given series.
   uint64 supply = 1 ;
 }
-message Unlimited {}
-
-message Fixed {}
 
 // Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
 message FixedSeries {

--- a/proto/brambl/models/box/asset.proto
+++ b/proto/brambl/models/box/asset.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package co.topl.brambl.models.box;
+
+message SeriesTokenSupply {
+  oneof value {
+    // we can mint as many tokens as we want of a given asset
+    Unlimited unlimited = 1;
+    // can only mint up to a certain amount of tokens of a given series.
+    Capped capped = 2;
+    // the same as capped but the network enforces that all tokens are minted in only one transaction.
+    Fixed fixed = 3;
+  }
+}
+
+message Capped {
+  uint64 supply = 1 ;
+}
+message Unlimited {}
+
+message Fixed {}
+
+// Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
+message FixedSeries {
+  // SHA256 series policy
+  string value = 1;
+}

--- a/proto/brambl/models/box/asset.proto
+++ b/proto/brambl/models/box/asset.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package co.topl.brambl.models.box;
-import 'validate/validate.proto';
 
 enum FungibilityType {
   // `group-and-series` means that both the series and the group are considered for fungibility.
@@ -13,8 +12,8 @@ enum FungibilityType {
 }
 
 enum QuantityDescriptorType{
-  // `standard` means that the token has the standard behavior. If it is fungible one can fraction it in smaller tokens or merge two smaller tokens to make a bigger one.
-  STANDARD = 0;
+  // `liquid` If it is fungible one can fraction it in smaller tokens or merge two smaller tokens to make a bigger one.
+  LIQUID = 0;
   // `accumulator` means that the token can only be merged with other fungible tokens. Once two tokens are merged they can never be separated and will always share the same UTXO.
   ACCUMULATOR = 1;
   // `fractionable` means that the token can only be split but not merged with other fungible tokens. Once the token was split it can never be put together again.

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -45,7 +45,7 @@ message Value {
   // A group constructor token
   message Group {
     // The group identifier of this group constructor token.
-    // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+    // The ID of _this_ Group.  This value is optional and its contents are included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
     // It is the digest of the Group Policy.
     GroupId groupId = 1;
@@ -57,7 +57,7 @@ message Value {
 
   // A series constructor token
   message Series {
-    // The ID of _this_ Series.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+    // The ID of _this_ Series.  This value is optional and its contents are included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
     // It is the digest of the Series Policy.
     SeriesId seriesId = 1;

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -48,7 +48,7 @@ message Value {
     // index of the output (UTXO) within the transaction targeted by id.
     uint32 index = 4;
     // group identifier, hash of (label + fixedSeries + seriesTokenSupply + txId + index)
-    string id = 6;
+    GroupId id = 6 [(validate.rules).message.required = true];
   }
 
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -8,9 +8,7 @@ import 'quivr/models/shared.proto';
 import 'consensus/models/staking.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/box/asset.proto';
-import 'brambl/models/address.proto';
-import "google/protobuf/struct.proto";
-
+import 'google/protobuf/wrappers.proto';
 
 // The value contained in a box
 message Value {
@@ -19,6 +17,7 @@ message Value {
     TOPL topl = 2;
     Asset asset = 3;
     Group group = 4;
+    Series series = 5;
   }
   // A payment token
   message LVL {
@@ -40,41 +39,32 @@ message Value {
 
   // A group constructor token
   message Group {
-    // Identifies the group policy for humans (do not confuse with the actual group identifier)
-    string label = 1;
-    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
-    SeriesId fixedSeries = 2;
-    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
-    TransactionOutputAddress transactionOutputAddress = 3 [(validate.rules).message.required = true];
+    // The group identifier of this group constructor token.
     // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
-    // Specification: GroupId: SHA-256(label + fixedSeries + transactionOutputAddress)
-    GroupId groupId = 4;
+    // It is the digest of the Group Policy.
+    GroupId groupId = 1;
+    // The quantity of group constructor tokens stored in a given UTXO.
+    quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
+    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
+    SeriesId fixedSeries = 3;
   }
 
   // A series constructor token
   message Series {
-    // The human readable name of this series. (do not confuse with the actual series identifier)
-    string label = 1;
-    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the series constructor token.
-    TransactionOutputAddress transactionOutputAddress = 2 [(validate.rules).message.required = true];
-    //  This is an optional field.
-    //  When provided it fixes the quantity of tokens that can be minted when this series is consumed,
-    //  and the series constructor is burned by the minting transaction.
-    //  When not provided, the series constructor is not burned, thus making the token supply unlimited.
-    quivr.models.Int128 tokenSupply = 3;
-    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
-    FungibilityType fungibility = 4;
-    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
-    QuantityDescriptorType quantityDescriptor = 5;
-    // Describes the schema of the data stored in the metadata field of the Asset Minting Statement.
-    google.protobuf.Struct ephemeralMetadataScheme = 6;
-    // Describes the schema of the data stored in the Asset Token.
-    google.protobuf.Struct permanentMetadataScheme = 7;
     // The ID of _this_ Series.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
-    // Specification: GroupId: SHA-256(label + transactionOutputAddress + tokenSupply + fungibility + quantityDescriptor)
-    SeriesId seriesId = 8;
+    // It is the digest of the Series Policy.
+    SeriesId seriesId = 1;
+    // The quantity of series constructor tokens stored in a given UTXO.
+    quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
+    // This is an optional field. When provided it fixes the quantity of tokens that will be minted when this series is consumed, 
+    // and the series constructor is burned by the minting transaction. 
+    // When not provided, the series constructor is not burned, thus making the token supply unlimited.
+    google.protobuf.UInt32Value tokenSupply = 3;
+    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
+    QuantityDescriptorType quantityDescriptor = 4;
+    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
+    FungibilityType fungibility = 5;
   }
-
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -41,16 +41,14 @@ message Value {
     string label = 1;
     // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
     FixedSeries fixedSeries = 2;
-    // Descriptor of how many series can be associated with this group
-    SeriesTokenSupply seriesTokenSupply = 3 [(validate.rules).message.required = true];
     // transaction id
-    TransactionId txId = 5 [(validate.rules).message.required = true];
+    TransactionId txId = 3 [(validate.rules).message.required = true];
     // index of the output (UTXO) within the transaction targeted by id.
     uint32 index = 4;
     // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
-    // Specification: GroupId: SHA-256(label + fixedSeries + seriesTokenSupply + txId + index)
-    GroupId groupId = 6;
+    // Specification: GroupId: SHA-256(label + fixedSeries + txId + index)
+    GroupId groupId = 5;
   }
 
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -8,6 +8,7 @@ import 'quivr/models/shared.proto';
 import 'consensus/models/staking.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/box/asset.proto';
+import 'brambl/models/address.proto';
 
 // The value contained in a box
 message Value {
@@ -41,14 +42,12 @@ message Value {
     string label = 1;
     // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
     FixedSeries fixedSeries = 2;
-    // transaction id
-    TransactionId txId = 3 [(validate.rules).message.required = true];
-    // index of the output (UTXO) within the transaction targeted by id.
-    uint32 index = 4;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
+    TransactionOutputAddress transactionOutputAddress = 3 [(validate.rules).message.required = true];
     // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
     // Specification: GroupId: SHA-256(label + fixedSeries + txId + index)
-    GroupId groupId = 5;
+    GroupId groupId = 4;
   }
 
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -7,6 +7,7 @@ import 'validate/validate.proto';
 import 'quivr/models/shared.proto';
 import 'consensus/models/staking.proto';
 import 'brambl/models/identifier.proto';
+import 'brambl/models/box/asset.proto';
 
 // The value contained in a box
 message Value {
@@ -50,27 +51,4 @@ message Value {
     string id = 6;
   }
 
-  message SeriesTokenSupply {
-    oneof value {
-      // we can mint as many tokens as we want of a given asset
-      Unlimited unlimited = 1;
-      // can only mint up to a certain amount of tokens of a given series.
-      Capped capped = 2;
-      // the same as capped but the network enforces that all tokens are minted in only one transaction.
-      Fixed fixed = 3;
-    }
-  }
-
-  message Capped {
-    uint64 supply = 1 ;
-  }
-  message Unlimited {}
-
-  message Fixed {}
-
-  // Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
-  message FixedSeries {
-    // SHA256 series policy
-    string value = 1;
-  }
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -50,7 +50,7 @@ message Value {
     // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
     // Specification: GroupId: SHA-256(label + fixedSeries + seriesTokenSupply + txId + index)
-    GroupId id = 6;
+    GroupId groupId = 6;
   }
 
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -8,6 +8,7 @@ import 'quivr/models/shared.proto';
 import 'consensus/models/staking.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/box/asset.proto';
+import 'brambl/models/event.proto';
 import 'google/protobuf/wrappers.proto';
 
 // The value contained in a box
@@ -48,6 +49,8 @@ message Value {
     quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
     // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
     SeriesId fixedSeries = 3;
+    // Group Policy
+    Event.GroupPolicy groupPolicy = 4 [(validate.rules).message.required = true];
   }
 
   // A series constructor token
@@ -66,5 +69,7 @@ message Value {
     QuantityDescriptorType quantityDescriptor = 4;
     //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
     FungibilityType fungibility = 5;
+    // Group Policy
+    Event.SeriesPolicy seriesPolicy = 6 [(validate.rules).message.required = true];
   }
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -6,29 +6,71 @@ import 'validate/validate.proto';
 
 import 'quivr/models/shared.proto';
 import 'consensus/models/staking.proto';
+import 'brambl/models/identifier.proto';
 
 // The value contained in a box
 message Value {
+  oneof value {
+    LVL lvl = 1;
+    TOPL topl = 2;
+    Asset asset = 3;
+    Group group = 4;
+  }
+  // A payment token
+  message LVL {
+    quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
+  }
+  // A staking token
+  message TOPL {
+    quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
+    // Optional.  If provided, the registration will take effect at the start of 2 epochs from now. If not provided, this token will not be used for staking purposes.
+    co.topl.consensus.models.StakingRegistration registration = 3;
+
+  }
+  // A user-defined token
+  message Asset {
+    string label = 1;
+    quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
+    quivr.models.SmallData metadata = 3 [(validate.rules).message.required = true];
+  }
+
+  // A group constructor token
+  message Group {
+    // Identifies the group policy for humans (do not confuse with the actual group identifier)
+    string label = 1;
+    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
+    FixedSeries fixedSeries = 2;
+    // Descriptor of how many series can be associated with this group
+    SeriesTokenSupply seriesTokenSupply = 3 [(validate.rules).message.required = true];
+    // transaction id
+    TransactionId txId = 5 [(validate.rules).message.required = true];
+    // index of the output (UTXO) within the transaction targeted by id.
+    uint32 index = 4;
+    // group identifier, hash of (label + fixedSeries + seriesTokenSupply + txId + index)
+    string id = 6;
+  }
+
+  message SeriesTokenSupply {
     oneof value {
-        LVL lvl = 1;
-        TOPL topl = 2;
-        Asset asset = 3;
+      // we can mint as many tokens as we want of a given asset
+      Unlimited unlimited = 1;
+      // can only mint up to a certain amount of tokens of a given series.
+      Capped capped = 2;
+      // the same as capped but the network enforces that all tokens are minted in only one transaction.
+      Fixed fixed = 3;
     }
-    // A payment token
-    message LVL {
-        quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
-    }
-    // A staking token
-    message TOPL {
-        quivr.models.Int128 quantity = 1 [(validate.rules).message.required = true];
-        // Optional.  If provided, the registration will take effect at the start of 2 epochs from now. If not provided, this token will not be used for staking purposes.
-        co.topl.consensus.models.StakingRegistration registration = 3;
-        
-    }
-    // A user-defined token
-    message Asset {
-        string label = 1;
-        quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
-        quivr.models.SmallData metadata = 3 [(validate.rules).message.required = true];
-    }
+  }
+
+  message Capped {
+    uint64 supply = 1 ;
+  }
+  message Unlimited {}
+
+  message Fixed {}
+
+  // Fix a group identifier to a particular series, thus only allowing that group to be used to mint asset tokens with that series.
+  message FixedSeries {
+    // SHA256 series policy
+    string value = 1;
+  }
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -53,8 +53,6 @@ message Value {
     quivr.models.Int128 quantity = 2 [(validate.rules).message.required = true];
     // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
     SeriesId fixedSeries = 3;
-    // Group Policy
-    Event.GroupPolicy groupPolicy = 4 [(validate.rules).message.required = true];
   }
 
   // A series constructor token
@@ -73,8 +71,6 @@ message Value {
     QuantityDescriptorType quantityDescriptor = 4;
     //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
     FungibilityType fungibility = 5;
-    // Group Policy
-    Event.SeriesPolicy seriesPolicy = 6 [(validate.rules).message.required = true];
   }
 
   message UpdateProposal {

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -9,6 +9,8 @@ import 'consensus/models/staking.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/box/asset.proto';
 import 'brambl/models/address.proto';
+import "google/protobuf/struct.proto";
+
 
 // The value contained in a box
 message Value {
@@ -41,13 +43,38 @@ message Value {
     // Identifies the group policy for humans (do not confuse with the actual group identifier)
     string label = 1;
     // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
-    FixedSeries fixedSeries = 2;
+    SeriesId fixedSeries = 2;
     // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
     TransactionOutputAddress transactionOutputAddress = 3 [(validate.rules).message.required = true];
     // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
     // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
-    // Specification: GroupId: SHA-256(label + fixedSeries + txId + index)
+    // Specification: GroupId: SHA-256(label + fixedSeries + transactionOutputAddress)
     GroupId groupId = 4;
+  }
+
+  // A series constructor token
+  message Series {
+    // The human readable name of this series. (do not confuse with the actual series identifier)
+    string label = 1;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the series constructor token.
+    TransactionOutputAddress transactionOutputAddress = 2 [(validate.rules).message.required = true];
+    //  This is an optional field.
+    //  When provided it fixes the quantity of tokens that can be minted when this series is consumed,
+    //  and the series constructor is burned by the minting transaction.
+    //  When not provided, the series constructor is not burned, thus making the token supply unlimited.
+    quivr.models.Int128 tokenSupply = 3;
+    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
+    FungibilityType fungibility = 4;
+    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
+    QuantityDescriptorType quantityDescriptor = 5;
+    // Describes the schema of the data stored in the metadata field of the Asset Minting Statement.
+    google.protobuf.Struct ephemeralMetadataScheme = 6;
+    // Describes the schema of the data stored in the Asset Token.
+    google.protobuf.Struct permanentMetadataScheme = 7;
+    // The ID of _this_ Series.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+    // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
+    // Specification: GroupId: SHA-256(label + transactionOutputAddress + tokenSupply + fungibility + quantityDescriptor)
+    SeriesId seriesId = 8;
   }
 
 }

--- a/proto/brambl/models/box/value.proto
+++ b/proto/brambl/models/box/value.proto
@@ -47,8 +47,10 @@ message Value {
     TransactionId txId = 5 [(validate.rules).message.required = true];
     // index of the output (UTXO) within the transaction targeted by id.
     uint32 index = 4;
-    // group identifier, hash of (label + fixedSeries + seriesTokenSupply + txId + index)
-    GroupId id = 6 [(validate.rules).message.required = true];
+    // The ID of _this_ Group.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+    // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
+    // Specification: GroupId: SHA-256(label + fixedSeries + seriesTokenSupply + txId + index)
+    GroupId id = 6;
   }
 
 }

--- a/proto/brambl/models/datum.proto
+++ b/proto/brambl/models/datum.proto
@@ -4,12 +4,6 @@ package co.topl.brambl.models;
 
 import 'validate/validate.proto';
 import 'brambl/models/event.proto';
-import 'google/protobuf/wrappers.proto';
-import 'brambl/models/address.proto';
-import 'brambl/models/box/asset.proto';
-import 'brambl/models/identifier.proto';
-
-import "google/protobuf/struct.proto";
 
 // Datums represent a queryable product value of the arguments available from a certain Event. Datum may be
 // evaluated during the Quivr protocol execution by providing events as Datum in a Dynamic Context.
@@ -40,29 +34,9 @@ message Datum {
     Event.IoTransaction event = 1 [(validate.rules).message.required = true];
   }
   message GroupPolicy {
-    // Identifies the group policy for humans (do not confuse with the actual group identifier)
-    string label = 1;
-    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
-    TransactionOutputAddress registrationUtxo = 2 [(validate.rules).message.required = true];
-    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
-    SeriesId fixedSeries = 3;
+    Event.GroupPolicy groupPolicy = 1 [(validate.rules).message.required = true];
   }
   message SeriesPolicy {
-    // The human readable name of this series. (do not confuse with the actual series identifier)
-    string label = 1;
-    // This is an optional field. When provided it fixes the quantity of tokens that will be minted when this series is consumed,
-    // and the series constructor is burned by the minting transaction.
-    // When not provided, the series constructor is not burned, thus making the token supply unlimited.
-    google.protobuf.UInt32Value tokenSupply = 2;
-    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the series constructor token.
-    TransactionOutputAddress registrationUtxo = 3 [(validate.rules).message.required = true];
-    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
-    brambl.models.box.QuantityDescriptorType quantityDescriptor = 4;
-    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
-    brambl.models.box.FungibilityType fungibility = 5;
-    // Describes the schema of the data stored in the metadata field of the Asset Minting Statement.
-    google.protobuf.Struct ephemeralMetadataScheme = 6;
-    // Describes the schema of the data stored in the Asset Token.
-    google.protobuf.Struct permanentMetadataScheme = 7;
+    Event.SeriesPolicy seriesPolicy = 1 [(validate.rules).message.required = true];
   }
 }

--- a/proto/brambl/models/datum.proto
+++ b/proto/brambl/models/datum.proto
@@ -4,31 +4,65 @@ package co.topl.brambl.models;
 
 import 'validate/validate.proto';
 import 'brambl/models/event.proto';
+import 'google/protobuf/wrappers.proto';
+import 'brambl/models/address.proto';
+import 'brambl/models/box/asset.proto';
+import 'brambl/models/identifier.proto';
+
+import "google/protobuf/struct.proto";
 
 // Datums represent a queryable product value of the arguments available from a certain Event. Datum may be
 // evaluated during the Quivr protocol execution by providing events as Datum in a Dynamic Context.
 message Datum {
-    oneof value {
-        Eon eon = 1;
-        Era era = 2;
-        Epoch epoch = 3;
-        Header header = 4;
-        IoTransaction ioTransaction = 5;
-    }
+  oneof value {
+    Eon eon = 1;
+    Era era = 2;
+    Epoch epoch = 3;
+    Header header = 4;
+    IoTransaction ioTransaction = 5;
+    GroupPolicy groupPolicy = 6;
+    SeriesPolicy seriesPolicy = 7;
+  }
 
-    message Eon {
-        Event.Eon event = 1 [(validate.rules).message.required = true];
-    }
-    message Era {
-        Event.Era event = 1 [(validate.rules).message.required = true];
-    }
-    message Epoch {
-        Event.Epoch event = 1 [(validate.rules).message.required = true];
-    }
-    message Header {
-        Event.Header event = 1 [(validate.rules).message.required = true];
-    }
-    message IoTransaction {
-        Event.IoTransaction event = 1 [(validate.rules).message.required = true];
-    }
+  message Eon {
+    Event.Eon event = 1 [(validate.rules).message.required = true];
+  }
+  message Era {
+    Event.Era event = 1 [(validate.rules).message.required = true];
+  }
+  message Epoch {
+    Event.Epoch event = 1 [(validate.rules).message.required = true];
+  }
+  message Header {
+    Event.Header event = 1 [(validate.rules).message.required = true];
+  }
+  message IoTransaction {
+    Event.IoTransaction event = 1 [(validate.rules).message.required = true];
+  }
+  message GroupPolicy {
+    // Identifies the group policy for humans (do not confuse with the actual group identifier)
+    string label = 1;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
+    TransactionOutputAddress registrationUtxo = 2 [(validate.rules).message.required = true];
+    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
+    SeriesId fixedSeries = 3;
+  }
+  message SeriesPolicy {
+    // The human readable name of this series. (do not confuse with the actual series identifier)
+    string label = 1;
+    // This is an optional field. When provided it fixes the quantity of tokens that will be minted when this series is consumed,
+    // and the series constructor is burned by the minting transaction.
+    // When not provided, the series constructor is not burned, thus making the token supply unlimited.
+    google.protobuf.UInt32Value tokenSupply = 2;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the series constructor token.
+    TransactionOutputAddress registrationUtxo = 3 [(validate.rules).message.required = true];
+    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
+    brambl.models.box.QuantityDescriptorType quantityDescriptor = 4;
+    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
+    brambl.models.box.FungibilityType fungibility = 5;
+    // Describes the schema of the data stored in the metadata field of the Asset Minting Statement.
+    google.protobuf.Struct ephemeralMetadataScheme = 6;
+    // Describes the schema of the data stored in the Asset Token.
+    google.protobuf.Struct permanentMetadataScheme = 7;
+  }
 }

--- a/proto/brambl/models/datum.proto
+++ b/proto/brambl/models/datum.proto
@@ -34,9 +34,9 @@ message Datum {
     Event.IoTransaction event = 1 [(validate.rules).message.required = true];
   }
   message GroupPolicy {
-    Event.GroupPolicy groupPolicy = 1 [(validate.rules).message.required = true];
+    Event.GroupPolicy event = 1 [(validate.rules).message.required = true];
   }
   message SeriesPolicy {
-    Event.SeriesPolicy seriesPolicy = 1 [(validate.rules).message.required = true];
+    Event.SeriesPolicy event = 1 [(validate.rules).message.required = true];
   }
 }

--- a/proto/brambl/models/event.proto
+++ b/proto/brambl/models/event.proto
@@ -6,45 +6,83 @@ import 'validate/validate.proto';
 
 import 'quivr/models/shared.proto';
 import 'brambl/models/transaction/schedule.proto';
+import 'brambl/models/address.proto';
+import 'brambl/models/box/asset.proto';
+import 'brambl/models/identifier.proto';
+
+import 'google/protobuf/wrappers.proto';
+import "google/protobuf/struct.proto";
 
 // Events are uniquely identifiable occurrences of state mutations within the blockchain protocol.
 // Each event is associated with certain data that may be updated every tick.
 message Event {
-    oneof value {
-        // hard fork
-        Eon eon = 1;
-        // configuration change
-        Era era = 2;
-        // length of time in slots where stake updates occur
-        Epoch epoch = 3;
-        // Header created
-        Header header = 4;
-        //IO Transaction
-        IoTransaction ioTransaction = 5;
-    }
+  oneof value {
+    // hard fork
+    Eon eon = 1;
+    // configuration change
+    Era era = 2;
+    // length of time in slots where stake updates occur
+    Epoch epoch = 3;
+    // Header created
+    Header header = 4;
+    //IO Transaction
+    IoTransaction ioTransaction = 5;
+    // Group policy
+    GroupPolicy groupPolicy = 6;
+    // Series policy
+    SeriesPolicy seriesPolicy = 7;
+  }
 
-    message Eon {
-        uint64 beginSlot = 1;
-        uint64 height = 2;
-    }
+  message Eon {
+    uint64 beginSlot = 1;
+    uint64 height = 2;
+  }
 
-    message Era {
-        uint64 beginSlot = 1;
-        uint64 height = 2;
-    }
+  message Era {
+    uint64 beginSlot = 1;
+    uint64 height = 2;
+  }
 
-    message Epoch {
-        uint64 beginSlot = 1;
-        uint64 height = 2;
-    }
+  message Epoch {
+    uint64 beginSlot = 1;
+    uint64 height = 2;
+  }
 
-    message Header {
-        uint64 height = 1;
-    }
+  message Header {
+    uint64 height = 1;
+  }
 
-    message IoTransaction {
-        //the range of acceptable slots the transaction can be accepted into
-        co.topl.brambl.models.transaction.Schedule schedule = 1 [(validate.rules).message.required = true];
-        quivr.models.SmallData metadata = 4 [(validate.rules).message.required = true];
-    }
+  message IoTransaction {
+    //the range of acceptable slots the transaction can be accepted into
+    co.topl.brambl.models.transaction.Schedule schedule = 1 [(validate.rules).message.required = true];
+    quivr.models.SmallData metadata = 4 [(validate.rules).message.required = true];
+  }
+
+  message GroupPolicy {
+    // Identifies the group policy for humans (do not confuse with the actual group identifier)
+    string label = 1;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the group constructor token.
+    TransactionOutputAddress registrationUtxo = 2 [(validate.rules).message.required = true];
+    // An optional series identifier. When this series identifier is defined, this groups that implement this policy can only be used to mint assets with the aforementioned series identifier
+    SeriesId fixedSeries = 3;
+  }
+
+  message SeriesPolicy {
+    // The human readable name of this series. (do not confuse with the actual series identifier)
+    string label = 1;
+    // This is an optional field. When provided it fixes the quantity of tokens that will be minted when this series is consumed,
+    // and the series constructor is burned by the minting transaction.
+    // When not provided, the series constructor is not burned, thus making the token supply unlimited.
+    google.protobuf.UInt32Value tokenSupply = 2;
+    // The address of a UTXO. The UTXO contains the LVLs that are paid for minting the series constructor token.
+    TransactionOutputAddress registrationUtxo = 3 [(validate.rules).message.required = true];
+    // Describes the behavior of the quantity field of the assets minted using the series constructor derived from this policy.
+    brambl.models.box.QuantityDescriptorType quantityDescriptor = 4;
+    //Describes the fungibility of the assets minted using the series constructor token derived from this policy.
+    brambl.models.box.FungibilityType fungibility = 5;
+    // Describes the schema of the data stored in the metadata field of the Asset Minting Statement.
+    google.protobuf.Struct ephemeralMetadataScheme = 6;
+    // Describes the schema of the data stored in the Asset Token.
+    google.protobuf.Struct permanentMetadataScheme = 7;
+  }
 }

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -4,7 +4,7 @@ package co.topl.brambl.models;
 
 import 'validate/validate.proto';
 
-// Represents the identifier of a Transction.  It is constructed from the evidence of the signable bytes of the Transaction.
+// Represents the identifier of a Transaction.  It is constructed from the evidence of the signable bytes of the Transaction.
 message TransactionId {
     // The evidence of the Transaction's signable bytes
     // length = 32

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -6,21 +6,29 @@ import 'validate/validate.proto';
 
 // Represents the identifier of a Transaction.  It is constructed from the evidence of the signable bytes of the Transaction.
 message TransactionId {
-    // The evidence of the Transaction's signable bytes
-    // length = 32
-    bytes value = 1 [(validate.rules).bytes.len = 32];
+  // The evidence of the Transaction's signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Represents the identifier of a Lock.  It is constructed from the evidence of the signable bytes of the Lock.
 message LockId {
-    // The evidence of the Lock's signable bytes
-    // length = 32
-    bytes value = 1 [(validate.rules).bytes.len = 32];
+  // The evidence of the Lock's signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Represents the identifier of an Accumulator Root.  It is constructed from the evidence of the signable bytes of the Lock.
 message AccumulatorRootId {
-    // The evidence of the Accumulator Root's signable bytes
-    // length = 32
-    bytes value = 1 [(validate.rules).bytes.len = 32];
+  // The evidence of the Accumulator Root's signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
+}
+
+// Represents the identifier of an TAM V2 group.
+// It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
+message GroupId {
+  // The evidence of the Group signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
 }

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -32,3 +32,11 @@ message GroupId {
   // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
+
+// Represents the identifier of an TAM V2 series.
+// It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
+message SeriesId {
+  // The evidence of the Group signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
+}

--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -21,7 +21,7 @@ message IoTransaction {
   // Datum
   co.topl.brambl.models.Datum.IoTransaction datum = 3 [(validate.rules).message.required = true];
   // 0-to-many list of group Policy
-  repeated co.topl.brambl.models.Datum.GroupPolicy groupPolicy = 5;
+  repeated co.topl.brambl.models.Datum.GroupPolicy groupPolicies = 5;
   // 0-to-many list of seriesPolicy
-  repeated co.topl.brambl.models.Datum.SeriesPolicy seriesPolicy = 6;
+  repeated co.topl.brambl.models.Datum.SeriesPolicy seriesPolicies = 6;
 }

--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -19,4 +19,6 @@ message IoTransaction {
     // 0-to-many list of outputs
     repeated UnspentTransactionOutput outputs = 2;
     co.topl.brambl.models.Datum.IoTransaction datum = 3 [(validate.rules).message.required = true];
+    co.topl.brambl.models.Datum.GroupPolicy groupPolicyDatum = 5;
+    co.topl.brambl.models.Datum.SeriesPolicy seriesPolicyDatum = 6;
 }

--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -11,14 +11,17 @@ import 'brambl/models/transaction/unspent_transaction_output.proto';
 
 // defines a transaction
 message IoTransaction {
-    // The ID of _this_ transaction.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
-    // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
-    co.topl.brambl.models.TransactionId transactionId = 4;
-    // 0-to-many list of inputs
-    repeated SpentTransactionOutput inputs = 1;
-    // 0-to-many list of outputs
-    repeated UnspentTransactionOutput outputs = 2;
-    co.topl.brambl.models.Datum.IoTransaction datum = 3 [(validate.rules).message.required = true];
-    co.topl.brambl.models.Datum.GroupPolicy groupPolicyDatum = 5;
-    co.topl.brambl.models.Datum.SeriesPolicy seriesPolicyDatum = 6;
+  // The ID of _this_ transaction.  This value is optional and its contents are not included in the signable or identifiable data.  Clients which _can_ verify
+  // this value should verify this value, but some clients may not be able to or need to, in which case this field acts as a convenience.
+  co.topl.brambl.models.TransactionId transactionId = 4;
+  // 0-to-many list of inputs
+  repeated SpentTransactionOutput inputs = 1;
+  // 0-to-many list of outputs
+  repeated UnspentTransactionOutput outputs = 2;
+  // Datum
+  co.topl.brambl.models.Datum.IoTransaction datum = 3 [(validate.rules).message.required = true];
+  // 0-to-many list of group Policy
+  repeated co.topl.brambl.models.Datum.GroupPolicy groupPolicy = 5;
+  // 0-to-many list of seriesPolicy
+  repeated co.topl.brambl.models.Datum.SeriesPolicy seriesPolicy = 6;
 }


### PR DESCRIPTION
## Purpose

TAMv2 Assets
A TAMv2 asset is a token that has the following attributes:
- A group identifier
- A series identifier
-  A quantity

Asset Lifecycle
- Mint a group constructor token
- Mint a series constructor token (this can be done in the same transaction as the group constructor is minted)
- Mint an asset token using the group and series constructor token just minted.

### Note

This PR is linked to the following PRs, and only group constructor token, with empty series was implemented.

- https://github.com/Topl/protobuf-specs/pull/78
- https://github.com/Topl/BramblSc/pull/86


## Approach  https://github.com/Topl/tips/tree/main/TIP-0003

- Implement models step1:  **group constructor token**
- Implement models step1:  **series constructor token**

## Testing
protobuf complie
## Tickets
step 1: https://topl.atlassian.net/browse/BN-909