### PR TITLE
BlockBody Reward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed[Release - v2.0.0-alpha2 | todo replace: next commit hash]
+### Changed[Release - v2.0.0-alpha3]
+- BlockBody message contains optional rewardTransactionId field
+- FullBlockBody message contains optional rewardTransaction field
+- Genus BlockData message replace `body` and `transactions` fields with a FullBody instance 
+
+## [Released]
+
+### Changed[Release - v2.0.0-alpha2]
 - Remove "Registration" Box Value
 - Create co.topl.consensus.models.StakingRegistration message
 - Create co.topl.consensus.models.ActiveStaker message
 - Remove "stakingAddress" field from Topl Box Value
 - Embed "StakingRegistration" in Topl Box Value
 
-### Added[Release - v2.0.0-alpha2 | todo replace: next commit hash]
+### Added[Release - v2.0.0-alpha2]
 - Retrieve Epoch Data Stats, Node rpc `fetchEpochData`
 
 ### Added[ae3f01d]

--- a/proto/genus/genus_models.proto
+++ b/proto/genus/genus_models.proto
@@ -153,6 +153,5 @@ message HeightData {
 // Data structure with the most important parts of a Block. Equivalent to a denormalized Full Block.
 message BlockData {
   consensus.models.BlockHeader header = 1 [(validate.rules).message.required = true];
-  node.models.BlockBody body = 2 [(validate.rules).message.required = true];
-  repeated brambl.models.transaction.IoTransaction transactions = 3;
+  node.models.FullBlockBody body = 4 [(validate.rules).message.required = true];
 }

--- a/proto/node/models/block.proto
+++ b/proto/node/models/block.proto
@@ -20,6 +20,8 @@ message BlockBody {
 message FullBlockBody {
   // A list of Transactions included in this block
   repeated co.topl.brambl.models.transaction.IoTransaction transactions = 1;
+  // An optional Transaction that represents the reward transaction for this block.
+  co.topl.brambl.models.transaction.IoTransaction rewardTransaction = 2;
 }
 
 // Captures the header and all transactions in a block

--- a/proto/node/models/block.proto
+++ b/proto/node/models/block.proto
@@ -12,6 +12,8 @@ import "validate/validate.proto";
 message BlockBody {
   // A list of Transaction IDs included in this block
   repeated co.topl.brambl.models.TransactionId transactionIds = 1;
+  // An optional Transaction ID that represents the reward transaction for this block.
+  co.topl.brambl.models.TransactionId rewardTransactionId = 2;
 }
 
 // Captures the ordering of transactions (not just IDs) within a block


### PR DESCRIPTION
## Purpose
- Block Producers need an incentive to run a node
- This incentive is captured as a reward, which is the accumulation of all fees paid in the block's transactions
- This reward is stored in the ledger as an additional Transaction, but it is encoded in a BlockBody as a separate field
## Approach
- Update BlockBody and FullBlockBody to contain an additional reward transaction field
- Also updated Genus BlockData to contain a FullBlockBody
## Testing
- Implemented in Bifrost
## Tickets
- #BN-1140