### PR TITLE
Fix Snapshot Versions

### DIFF
--- a/.github/workflows/_protoc_build.yml
+++ b/.github/workflows/_protoc_build.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Protoc
         run: |
@@ -22,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v3
@@ -33,7 +37,7 @@ jobs:
       - name: Setup SBT
         run: |
           mkdir -p $HOME/bin/sbt
-          set -eux && curl --fail --silent --location --retry 3 https://github.com/sbt/sbt/releases/download/v1.7.3/sbt-1.7.3.tgz | gunzip | tar x -C $HOME/bin/sbt
+          set -eux && curl --fail --silent --location --retry 3 https://github.com/sbt/sbt/releases/download/v1.9.0/sbt-1.9.0.tgz | gunzip | tar x -C $HOME/bin/sbt
           echo "$HOME/bin/sbt" >> $GITHUB_PATH
 
       - name: Compile and Test
@@ -45,6 +49,8 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Deploy (release only)
         run: sbt ci-release
         working-directory: ./build/scala


### PR DESCRIPTION
## Purpose
- Snapshot releases do not publish under the proper version on GitHub Actions
## Approach
- Update the GitHub workflows to fetch the entire git history, thus fetching all available tags as well
## Testing
- Correct version [here](https://github.com/Topl/protobuf-specs/actions/runs/5785945389)
## Tickets
N/A