### PR TITLE
revert scala3 cross publish is not working

### DIFF
--- a/.github/workflows/_protoc_build.yml
+++ b/.github/workflows/_protoc_build.yml
@@ -41,7 +41,7 @@ jobs:
           echo "$HOME/bin/sbt" >> $GITHUB_PATH
 
       - name: Compile and Test
-        run: sbt +publishLocal
+        run: sbt publishLocal
         working-directory: build/scala
   build-dart:
     name: Dart Build

--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -1,5 +1,4 @@
 val scala213 = "2.13.11"
-val scala33 = "3.3.0"
 
 inThisBuild(
   List(
@@ -9,7 +8,7 @@ inThisBuild(
 )
 
 lazy val commonSettings = Seq(
-  crossScalaVersions := Seq(scala213, scala33)
+  crossScalaVersions := Seq(scala213)
 )
 
 lazy val publishSettings = Seq(
@@ -46,7 +45,8 @@ lazy val protobuf =
     .settings(
       moduleName := "protobuf",
       commonSettings,
-      // publish / skip := true
+      // publish / skip := true,
+      crossScalaVersions := Nil
     )
     .aggregate(
       protobufFs2

--- a/build/scala/project/plugins.sbt
+++ b/build/scala/project/plugins.sbt
@@ -8,6 +8,6 @@ Seq(
 ).map(addSbtPlugin)
 
 libraryDependencies ++= Seq(
-  "com.thesamet.scalapb" %% "compilerplugin"           % "0.11.13",
-  "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.4"
+  "com.thesamet.scalapb" %% "compilerplugin"           % "0.11.11",
+  "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.1"
 )

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk11
 install:
-  - cd build/scala && sbt +publishM2
+  - cd build/scala && sbt publishM2


### PR DESCRIPTION
## Purpose
Scala 3 is not able to publish artifacts and is blocking releases.

"2023-08-29 16:30:40.382Z  info [SonatypeClient]     Failed: pom-staging, failureMessage:Invalid POM: /co/topl/protobuf_2.13/2.0.0-alpha4/protobuf_2.13-2.0.0-alpha4.pom: Project URL missing, License information missing, Developer information missing  - (SonatypeClient.scala:386)"

## Approach
revert and fix later
