### PR TITLE
include mintingAssestStatements

### DIFF
--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -8,6 +8,7 @@ import 'brambl/models/datum.proto';
 import 'brambl/models/identifier.proto';
 import 'brambl/models/transaction/spent_transaction_output.proto';
 import 'brambl/models/transaction/unspent_transaction_output.proto';
+import 'brambl/models/box/assets_statements.proto';
 
 // defines a transaction
 message IoTransaction {
@@ -24,4 +25,6 @@ message IoTransaction {
   repeated co.topl.brambl.models.Datum.GroupPolicy groupPolicies = 5;
   // 0-to-many list of seriesPolicy
   repeated co.topl.brambl.models.Datum.SeriesPolicy seriesPolicies = 6;
+  // 0-to-many list of minting asset statements
+  repeated co.topl.brambl.models.box.AssetMintingStatement mintingStatements = 7;
 }


### PR DESCRIPTION
## Purpose

include minting Assest Statements 

All Asset Minting Statements  are attached to the transaction.](https://github.com/Topl/tips/tree/main/TIP-0003#minting-of-an-asset-token)

