### PR TITLE
[BN-1018] Add gRPC Health Check Proto

### DIFF
--- a/proto/google/health_check.proto
+++ b/proto/google/health_check.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/proto/google/models/health_models.proto
+++ b/proto/google/models/health_models.proto
@@ -3,9 +3,9 @@ syntax = "proto3";
 package grpc.health.v1;
 
 enum ServingStatus {
-  UNKNOWN = 0;
-  SERVING = 1;
-  NOT_SERVING = 2;
+  UNKNOWN = 0; // Default status. Indicates that no stats was returned.
+  SERVING = 1; // Service is in a healthy state.
+  NOT_SERVING = 2; // Service is unhealthy. Reason is implementation specific.
   SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
 }
 

--- a/proto/google/models/health_models.proto
+++ b/proto/google/models/health_models.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+enum ServingStatus {
+  UNKNOWN = 0;
+  SERVING = 1;
+  NOT_SERVING = 2;
+  SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+}
+

--- a/proto/google/services/health_rpc.proto
+++ b/proto/google/services/health_rpc.proto
@@ -2,17 +2,13 @@ syntax = "proto3";
 
 package grpc.health.v1;
 
+import 'google/models/health_models.proto';
+
 message HealthCheckRequest {
   string service = 1;
 }
 
 message HealthCheckResponse {
-  enum ServingStatus {
-    UNKNOWN = 0;
-    SERVING = 1;
-    NOT_SERVING = 2;
-    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
-  }
   ServingStatus status = 1;
 }
 


### PR DESCRIPTION
## Purpose
Add health check proto. 

## Approach
The proto comes from: https://github.com/grpc/grpc/blob/master/doc/health-checking.md

## Testing
Built locally, implemented in Bifrrost, deployed to GKE and ensured that the `grpc` liveliness/readiness probes succeeded.

## Tickets
