### PR TITLE
Bn 1252 update proposal validation step 2

### DIFF
--- a/proto/brambl/models/box/update_proposal_statements.proto
+++ b/proto/brambl/models/box/update_proposal_statements.proto
@@ -5,8 +5,11 @@ package co.topl.brambl.models.box;
 import 'validate/validate.proto';
 
 import 'brambl/models/address.proto';
+import 'brambl/models/identifier.proto';
 
 message UpdateProposalMintingStatement {
+  // The ID of the UpdateProposalId
+  UpdateProposalId updateProposalId = 1 [(validate.rules).message.required = true];
   // The address of a UTXO. The UTXO contains the TOPLs that are paid for minting the update proposal token.
-  TransactionOutputAddress registrationUtxo = 1 [(validate.rules).message.required = true];
+  TransactionOutputAddress registrationUtxo = 2 [(validate.rules).message.required = true];
 }

--- a/proto/brambl/models/box/update_proposal_statements.proto
+++ b/proto/brambl/models/box/update_proposal_statements.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package co.topl.brambl.models.box;
+
+import 'validate/validate.proto';
+
+import 'brambl/models/address.proto';
+
+message UpdateProposalMintingStatement {
+  // The address of a UTXO. The UTXO contains the TOPLs that are paid for minting the update proposal token.
+  TransactionOutputAddress registrationUtxo = 1 [(validate.rules).message.required = true];
+}

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -25,7 +25,7 @@ message AccumulatorRootId {
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
-// Represents the identifier of an TAM V2 group.
+// Represents the identifier of a TAM V2 group.
 // It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
 message GroupId {
   // The evidence of the Group signable bytes
@@ -33,10 +33,18 @@ message GroupId {
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
-// Represents the identifier of an TAM V2 series.
+// Represents the identifier of a TAM V2 series.
 // It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
 message SeriesId {
   // The evidence of the Group signable bytes
+  // length = 32
+  bytes value = 1 [(validate.rules).bytes.len = 32];
+}
+
+// Represents the identifier of an UpdateProposal
+// It is constructed using SHA-256 digest of the UpdateProposal.
+message UpdateProposalId {
+  // The evidence of the UpdateProposal signable bytes
   // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }

--- a/proto/brambl/models/transaction/io_transaction.proto
+++ b/proto/brambl/models/transaction/io_transaction.proto
@@ -9,6 +9,7 @@ import 'brambl/models/identifier.proto';
 import 'brambl/models/transaction/spent_transaction_output.proto';
 import 'brambl/models/transaction/unspent_transaction_output.proto';
 import 'brambl/models/box/assets_statements.proto';
+import 'brambl/models/box/update_proposal_statements.proto';
 
 // defines a transaction
 message IoTransaction {
@@ -31,4 +32,6 @@ message IoTransaction {
   repeated co.topl.brambl.models.box.AssetMergingStatement mergingStatements = 8;
   // 0-to-many list of splitting asset statements
   repeated co.topl.brambl.models.box.AssetSplittingStatement splittingStatements = 9;
+  // 0-to-many list of minting update proposal statements
+  repeated co.topl.brambl.models.box.UpdateProposalMintingStatement updateProposalMintingStatements = 10;
 }


### PR DESCRIPTION
## Purpose
-  Mint an update proposal using the same utxo is not allowed
-  Each statement should reference a valid input TOPL, and it is not burned
- Transfer update proposal is not allowed, if exists an output should come from a minting statements

## Approach
- new UpdateProposalMintingStatement which will reference the topl utxo

## Testing
compile

## Tickets
* BN-1252
