### PR TITLE
BN-1310-node-g-rpc-service-admin  (do NOT merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.0.0-beta1] - 	
+
+### Added
+- Admin Rpc service.
+
+## [Released]
+
+## [v2.0.0-beta0] - Mon Nov 13 18:59:49 UTC 2023	
+
+### Changed
+- Change requerments for host known name
+- Refactor Ratio message, moved to Quivr/shared
+- Io Transaction includes includes merging and splitting statements
+
+
 ## [v2.0.0-alpha6] - Tue Sep 19 20:21:28 UTC 2023
 
 ### Added
 - Refactor Ratio message, moved to Quivr/shared
 - Io Transaction includes includes merging and splitting statements
 
-## [Released]
 
 ## [v2.0.0-alpha5] - Tue Sep 19 20:21:28 UTC 2023	
 

--- a/proto/node/services/bifrost_admin_rpc.proto
+++ b/proto/node/services/bifrost_admin_rpc.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package co.topl.node.services;
+
+service NodeAdminRpc {
+    // retrieve node software version
+    rpc FetchSoftwareVersion (FetchSoftwareVersionReq) returns (FetchSoftwareVersionRes);
+}
+
+// Request type for FetchSoftwareVersion
+message FetchSoftwareVersionReq {}
+  
+// Response type for FetchSoftwareVersion
+message FetchSoftwareVersionRes {
+string version = 1;
+}


### PR DESCRIPTION
## Purpose

Node gRPC service "Admin"

it will be used to :
- fetch software version (implemented)
- updating staking reward address (TBD)
- restarting block producing (TBD)
- clear banned peers (TBD)

------

## Approach
- a new service definition model

## Testing

```
fernando@fernando-um700:~/topl/Bifrost$ gwhisper localhost:9086 co.topl.node.services.NodeAdminRpc FetchSoftwareVersion
2023-11-27 11:42:38: Received message:
| version = "2.0.0-alpha10-46-00a3273d-20231127-1141"
RPC succeeded :D
fernando@fernando-um700:~/topl/Bifrost$ 
```

## Tickets  
BN- 1310


