### PR TITLE
Update image lock definition with proposition Id

### DIFF
--- a/proto/brambl/models/box/lock.proto
+++ b/proto/brambl/models/box/lock.proto
@@ -27,7 +27,7 @@ message Lock {
     // Semi-public information
     // The most commonly shared construction between parties
     message Image {
-        repeated co.topl.brambl.models.LockId leaves = 1;
+        repeated co.topl.brambl.models.PropositionId leaves = 1;
         uint32 threshold = 2;
     }
 

--- a/proto/brambl/models/identifier.proto
+++ b/proto/brambl/models/identifier.proto
@@ -6,37 +6,32 @@ import 'validate/validate.proto';
 
 // Represents the identifier of a Transaction.  It is constructed from the evidence of the signable bytes of the Transaction.
 message TransactionId {
-  // The evidence of the Transaction's signable bytes
-  // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Represents the identifier of a Lock.  It is constructed from the evidence of the signable bytes of the Lock.
 message LockId {
-  // The evidence of the Lock's signable bytes
-  // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
-// Represents the identifier of an Accumulator Root.  It is constructed from the evidence of the signable bytes of the Lock.
+// Represents the identifier of a Proposition.  It is constructed from the immutable bytes definition.
+message PropositionId {
+  bytes value = 1 [(validate.rules).bytes.len = 32];
+}
+
+// Represents the identifier of an Accumulator Root.  It is constructed from the immutable bytes definition.
 message AccumulatorRootId {
-  // The evidence of the Accumulator Root's signable bytes
-  // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Represents the identifier of an TAM V2 group.
 // It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
 message GroupId {
-  // The evidence of the Group signable bytes
-  // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }
 
 // Represents the identifier of an TAM V2 series.
 // It is constructed using SHA-256 digest from fields label+fixedSeries+seriesTokenSupply+transactionId+utxoIndex.
 message SeriesId {
-  // The evidence of the Group signable bytes
-  // length = 32
   bytes value = 1 [(validate.rules).bytes.len = 32];
 }


### PR DESCRIPTION
## Purpose
Creation and evaluation of `Lock.Image` values seems circular given their current definition of `Lock.Image(leaves: List[LockId], threshold: Int)` where `LockId` seems expected to be a `LockId` of a `Lock.Predicate`. This was not the original intention. Instead, `Lock.Image` should contain a `List[PropositionId]` where such an id is given by `ContainsEvidence[Proposition].sizedEvidence(p).digest.value`. In this way, `TransactionAuthorizationInterpreter` in Brambl may be updated to to ensure `known.map(_.sizedEvidence.digest.value) == leaves`. This may also provide a path for verifying the `AccumulatorRootId` with the `def merkleRootFromBlake2bEvidence: ContainEvidence[List[T]]` such that `ContainsEvidence[List[Proposition]].sizedEvidence(list).digest.value == AccumulatorRootId.value`

## Approach
- Added `PropositionId` which should have value `ContainsEvidence[Proposition].digest.value`
- Updated `Lock.Image` definition to use `PropositionId` instead of `LockId`

## Testing
** unsure of the best way to go about this **